### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: 🐛 Bug report
+description: Create a report to help us improve 🎉
+labels:
+  - bug
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: If applicable, add logs to help explain the bug.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps To Reproduce
+      description: Describe steps to reproduce the behavior
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question
+    url: https://github.com/appuio/appuio-cloud-community/discussions
+    about: Ask or discuss with us, we're happy to help 🙋

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project 💡
+labels:
+  - enhancement
+
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      value: |
+        **As** "role name"\
+        **I want** "a feature or functionality"\
+        **So that** "I get certain business value"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Add more information here. You are completely free regarding form and length.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: List aspects that are explicitly not part of this feature
+      placeholder: |
+        - ...
+        - ...
+        - ...
+    validations:
+      required: false
+  - type: textarea
+    id: links
+    attributes:
+      label: Further links
+      description: URLs of relevant Git repositories, PRs, Issues, etc.
+      placeholder: |
+        - #567
+        - https://kubernetes.io/docs/reference/
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: If you already have ideas what the requirements are, please list them below in given-when-then expressions.
+      placeholder: |
+        - Given a precondition, when an action happens, then expect a result
+        - Given a precondition, when an action happens, then expect a result
+        - Given a precondition, when an action happens, then expect a result
+    validations:
+      required: false
+  - type: textarea
+    id: implementation_idea
+    attributes:
+      label: Implementation Ideas
+      description: If applicable, shortly list possible implementation ideas
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+
+
+## Checklist
+
+- [ ] Categorize the PR by setting a good title and adding one of the labels:
+      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
+      as they show up in the changelog
+- [ ] Update tests.
+- [ ] Link this PR to related issues.
+
+<!--
+Remove items that do not apply. For completed items, change [ ] to [x].
+
+NOTE: these things are not required to open a PR and can be done afterwards,
+while the PR is open.
+-->


### PR DESCRIPTION
* Add PR template
* Configures GH forms to create new Issues for more standardized and refined issues.
* Links to https://github.com/appuio/appuio-cloud-community/discussions to discuss questions/support