### PR TITLE
Add Docker build in GH workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,9 @@
 name: Build
-on: [ push ]
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
 on: [ push ]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -13,20 +16,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
-      - uses: cypress-io/github-action@v2
-        with:
-          build: npm run build
-          start: npm run http-server
-      - uses: actions/upload-artifact@v2
-        with:
-          name: e2e-videos
-          path: cypress/videos
   test:
     runs-on: ubuntu-latest
     steps:
@@ -51,3 +40,62 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+  e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - lint
+      - test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: cypress-io/github-action@v2
+        with:
+          start: npm run http-server
+      - uses: actions/upload-artifact@v2
+        with:
+          name: e2e-videos
+          path: cypress/videos
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - e2e
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,10 @@
 name: Build
 on: [ push ]
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -20,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -32,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -48,12 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - lint
-      - test
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
       - uses: actions/download-artifact@v2
         with:
           name: dist
@@ -67,35 +54,16 @@ jobs:
           path: cypress/videos
   docker:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
-      - e2e
+      - build
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
       - uses: actions/download-artifact@v2
         with:
           name: dist
           path: dist
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
+          push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,21 +9,17 @@ env:
 jobs:
   dist:
     runs-on: ubuntu-latest
-    needs:
-      - lint
-      - test
-      - build
-      - e2e
-      - docker
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/setup-node@v2
         with:
-          name: dist
-          path: dist
+          node-version: '16'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,16 +3,48 @@ on:
   push:
     tags:
       - v*
-
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   dist:
     runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+      - build
+      - e2e
+      - docker
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
 
-      # TODO: Add build steps here
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build changelog from PRs with labels
         id: build_changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginxinc/nginx-unprivileged:1.21.4
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY dist/cloud-portal/en-CH /usr/share/nginx/html

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 8080;
+    server_name  localhost;
+    location / {
+         root   /usr/share/nginx/html;
+         index  index.html;
+
+         try_files $uri $uri/ /index.html?$args;
+    }
+}


### PR DESCRIPTION
## Summary

Build and publish a docker image to `ghcr.io`. 
The docker image is based on nginx (nginxinc/nginx-unprivileged) and contains a default configuration for an angular project.

Closes https://github.com/appuio/cloud-portal/issues/3

