### PR TITLE
Automatic deployments to preview in PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,17 @@
 name: Build
+
 on:
   push:
     branches:
       - master
   pull_request: {}
+
+env:
+  REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
+  NAMESPACE:  appuio-cloud-preview
+  IMAGE_NAME: appuio-cloud-preview/cloud-portal
+  IMG_TAG_PREVIEW: pr-${{ github.event.number }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -15,6 +23,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -25,6 +34,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run test
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +49,7 @@ jobs:
         with:
           name: dist
           path: dist
+
   e2e:
     runs-on: ubuntu-latest
     needs:
@@ -56,6 +67,7 @@ jobs:
         with:
           name: e2e-videos
           path: cypress/videos
+
   docker:
     runs-on: ubuntu-latest
     needs:
@@ -66,8 +78,35 @@ jobs:
         with:
           name: dist
           path: dist
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: registry.cloudscale-lpg-2.appuio.cloud
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.OPENSHIFT_TOKEN_PREVIEW }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    uses: ./.github/workflows/setup_deploy.yaml@${{ github.ref }}
+    with:
+      namespace: ${{ env.NAMESPACE }}
+      openshift_api_url: ${{ env.OPENSHIFT_API }}
+    secrets:
+      openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+    needs:
+      - docker

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,8 +106,9 @@ jobs:
     with:
       namespace: appuio-cloud-preview
       openshift_api_url: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
-      helm_release_name: pr-${{ github.event.number }}
+      helm_release_name: portal-pr-${{ github.event.number }}
       image_tag: pr-${{ github.event.number }}
+      revision: ${{ github.event.pull_request.head.sha }}
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,9 +8,7 @@ on:
 
 env:
   REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
-  NAMESPACE:  appuio-cloud-preview
   IMAGE_NAME: appuio-cloud-preview/cloud-portal
-  IMG_TAG_PREVIEW: pr-${{ github.event.number }}
 
 jobs:
   lint:
@@ -84,12 +82,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
+          # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Docker login
         uses: docker/login-action@v1
         with:
-          registry: registry.cloudscale-lpg-2.appuio.cloud
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.OPENSHIFT_TOKEN }}
 
@@ -107,6 +106,7 @@ jobs:
     with:
       namespace: appuio-cloud-preview
       openshift_api_url: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
+      helm_release_name: pr-${{ github.event.number }}
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
 
   deploy:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
-    uses: ./.github/workflows/setup_deploy.yaml@${{ github.ref }}
+    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
     with:
       namespace: ${{ env.NAMESPACE }}
       openshift_api_url: ${{ env.OPENSHIFT_API }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,6 +107,7 @@ jobs:
       namespace: appuio-cloud-preview
       openshift_api_url: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
       helm_release_name: pr-${{ github.event.number }}
+      image_tag: pr-${{ github.event.number }}
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    environment: preview
     needs:
       - build
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           registry: registry.cloudscale-lpg-2.appuio.cloud
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.OPENSHIFT_TOKEN_PREVIEW }}
+          password: ${{ secrets.OPENSHIFT_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
@@ -104,8 +104,8 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
     uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
     with:
-      namespace: ${{ env.NAMESPACE }}
-      openshift_api_url: ${{ env.OPENSHIFT_API }}
+      namespace: appuio-cloud-preview
+      openshift_api_url: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
-  IMAGE_NAME: appuio-cloud-preview/cloud-portal
+  IMAGE_NAME: cloud-portal
 
 jobs:
   lint:
@@ -83,7 +83,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/appuio-cloud-preview/${{ env.IMAGE_NAME }}
 
       - name: Docker login
         uses: docker/login-action@v1
@@ -105,7 +105,6 @@ jobs:
     uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
     with:
       namespace: appuio-cloud-preview
-      openshift_api_url: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
       helm_release_name: portal-pr-${{ github.event.number }}
       image_tag: pr-${{ github.event.number }}
       revision: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -1,0 +1,85 @@
+name: Undeploy
+
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  ENVIRONMENT: preview
+  OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
+  HELM_RELEASE_NAME: portal-pr-${{ github.event.number }}
+  IMG_TAG: pr-${{ github.event.number }}
+  NAMESPACE: appuio-cloud-preview
+  IMAGE_NAME: cloud-portal
+
+jobs:
+  uninstall:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    environment: preview
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v0.9.0
+        with:
+          helm-version: v3.7.1
+          helmfile-version: v0.142.0
+          install-kubectl: false
+          additional-helm-plugins: https://github.com/aslafy-z/helm-git --version 0.11.1
+
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
+      - name: Authenticate and set context
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ env.OPENSHIFT_API }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: ${{ env.NAMESPACE }}
+          # We don't have a LE cert yet
+          insecure_skip_tls_verify: true
+
+      - name: Uninstall app
+        run: helmfile --namespace ${{ env.NAMESPACE }} --file deployment/helmfile.yaml -e ${{ env.ENVIRONMENT }} destroy --args --wait
+        env:
+          HELM_RELEASE_NAME: ${{ env.HELM_RELEASE_NAME }}
+          IMG_TAG: none
+
+      - name: Delete image in registry
+        run: oc -n ${{ env.NAMESPACE }} delete imagestreamtags ${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }} --ignore-not-found
+
+      - name: Notify on success
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## ✔️ Preview deployment uninstalled
+
+            | | |
+            |-|-|
+            **Helm release** | ${{ env.NAMESPACE }}/${{ env.HELM_RELEASE_NAME }}
+            **Cluster** | ${{ env.OPENSHIFT_API }}
+
+      - name: Notify on failure
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ failure() }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## ❌ Failed to remove preview deployment
+
+            | | |
+            |-|-|
+            **Helm release** | ${{ env.NAMESPACE }}/${{ env.HELM_RELEASE_NAME }}
+            **Cluster** | ${{ env.OPENSHIFT_API }}
+
+            Please investigate what went wrong in the GitHub actions logs.
+            Maintainers can manually remove the deployment by running
+            ```bash
+            helmfile -n ${{ env.NAMESPACE }} -f deployment/helmfile.yaml -e ${{ env.ENVIRONMENT }} destroy
+            oc -n ${{ env.NAMESPACE }} delete imagestreamtags ${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }} --ignore-not-found
+            ```

--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -10,7 +10,7 @@ env:
   OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
   HELM_RELEASE_NAME: portal-pr-${{ github.event.number }}
   IMG_TAG: pr-${{ github.event.number }}
-  NAMESPACE: appuio-cloud-preview
+  NAMESPACE: appuio-control-api-preview
   IMAGE_NAME: cloud-portal
 
 jobs:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,13 +3,49 @@ name: PullRequest
 on:
   pull_request: {}
 
+env:
+  REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
+  NAMESPACE: appuio-cloud-preview
+  IMAGE_NAME: cloud-portal
+
 jobs:
 
   build:
     uses: appuio/cloud-portal/.github/workflows/template-build.yaml@preview-deployments
-    with:
-      namespace: appuio-cloud-preview
-      push_image: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+
+  docker:
+    runs-on: ubuntu-latest
+    environment: preview
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
+
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.OPENSHIFT_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   deploy:
     # Don't deploy with Renovate PRs
@@ -24,3 +60,4 @@ jobs:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
     needs:
       - build
+      - docker

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,13 +5,13 @@ on:
 
 env:
   REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
-  NAMESPACE: appuio-cloud-preview
+  NAMESPACE: appuio-control-api-preview
   IMAGE_NAME: cloud-portal
 
 jobs:
 
   build:
-    uses: appuio/cloud-portal/.github/workflows/template-build.yaml@preview-deployments
+    uses: appuio/cloud-portal/.github/workflows/template-build.yaml@master
 
   docker:
     runs-on: ubuntu-latest
@@ -50,9 +50,9 @@ jobs:
   deploy:
     # Don't deploy with Renovate PRs
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
-    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
+    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@master
     with:
-      namespace: appuio-cloud-preview
+      namespace: appuio-control-api-preview
       helm_release_name: portal-pr-${{ github.event.number }}
       image_tag: pr-${{ github.event.number }}
       revision: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,26 @@
+name: PullRequest
+
+on:
+  pull_request: {}
+
+jobs:
+
+  build:
+    uses: appuio/cloud-portal/.github/workflows/template-build.yaml@preview-deployments
+    with:
+      namespace: appuio-cloud-preview
+      push_image: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+
+  deploy:
+    # Don't deploy with Renovate PRs
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
+    with:
+      namespace: appuio-cloud-preview
+      helm_release_name: portal-pr-${{ github.event.number }}
+      image_tag: pr-${{ github.event.number }}
+      revision: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+    needs:
+      - build

--- a/.github/workflows/template-build.yaml
+++ b/.github/workflows/template-build.yaml
@@ -1,10 +1,13 @@
-name: Build
-
 on:
-  push:
-    branches:
-      - master
-  pull_request: {}
+  workflow_call:
+    inputs:
+      namespace:
+        type: string
+        required: true
+      push_image:
+        type: boolean
+        required: false
+        default: false
 
 env:
   REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
@@ -33,7 +36,7 @@ jobs:
       - run: npm ci
       - run: npm run test
 
-  build:
+  dist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +54,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -70,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: preview
     needs:
-      - build
+      - dist
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -83,9 +86,10 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
-          images: ${{ env.REGISTRY }}/appuio-cloud-preview/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/${{ env.IMAGE_NAME }}
 
       - name: Docker login
+        if: ${{ inputs.push_image }}
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -96,19 +100,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: ${{ inputs.push_image }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-  deploy:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
-    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@preview-deployments
-    with:
-      namespace: appuio-cloud-preview
-      helm_release_name: portal-pr-${{ github.event.number }}
-      image_tag: pr-${{ github.event.number }}
-      revision: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-    needs:
-      - docker

--- a/.github/workflows/template-build.yaml
+++ b/.github/workflows/template-build.yaml
@@ -1,17 +1,5 @@
 on:
-  workflow_call:
-    inputs:
-      namespace:
-        type: string
-        required: true
-      push_image:
-        type: boolean
-        required: false
-        default: false
-
-env:
-  REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
-  IMAGE_NAME: cloud-portal
+  workflow_call: {}
 
 jobs:
   lint:
@@ -68,38 +56,3 @@ jobs:
         with:
           name: e2e-videos
           path: cypress/videos
-
-  docker:
-    runs-on: ubuntu-latest
-    environment: preview
-    needs:
-      - dist
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
-          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/${{ env.IMAGE_NAME }}
-
-      - name: Docker login
-        if: ${{ inputs.push_image }}
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.OPENSHIFT_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: ${{ inputs.push_image }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: preview
-      url: ${{ steps.deployment_info.outputs.route_host }}
+      url: https://${{ steps.deployment_info.outputs.route_host }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -25,6 +25,8 @@ jobs:
       name: preview
       url: ${{ steps.deployment_info.outputs.route_host }}
     steps:
+      - uses: actions/checkout@v2
+
       - name: Setup helmfile
         uses: mamezou-tech/setup-helmfile@v0.9.0
         with:

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -7,12 +7,16 @@ on:
       openshift_api_url:
         type: string
         required: true
+      helm_release_name:
+        type: string
+        default: portal
+        required: false
     secrets:
       openshift_token:
         required: true
 
 jobs:
-  deploy:
+  install:
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -40,9 +44,9 @@ jobs:
           insecure_skip_tls_verify: true
 
       - name: Deploy app
-        run: helmfile --namespace ${{ env.NAMESPACE }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
+        run: helmfile --namespace ${{ input.namespace }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
         env:
-          HELM_RELEASE_NAME: ${{ env.HELM_RELEASE_NAME }}
+          HELM_RELEASE_NAME: ${{ inputs.helm_release_name }}
           IMG_TAG: ${{ env.IMG_TAG }}
           #GIT_SHA: ${{ github.event.pull_request.head.sha }}
 
@@ -50,7 +54,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: deployment_info
         run: |
-          echo ::set-output name=route_host::"$(oc -n ${{ env.NAMESPACE }} get route ${{ env.HELM_RELEASE_NAME }} -o jsonpath='{.spec.host}')"
+          echo ::set-output name=route_host::"$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')"
 
       - name: Make comment in PR
         uses: peter-evans/create-or-update-comment@v1
@@ -64,7 +68,7 @@ jobs:
             |-|-|
             **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
             **Revision** | ${{ github.event.pull_request.head.sha }}
-            **Helm release** | ${{ env.NAMESPACE }}/${{ env.HELM_RELEASE_NAME }}
+            **Helm release** | ${{ inputs.namespace }}/${{ inputs.helm_release_name }}
             **Cluster** | ${{ env.OPENSHIFT_API }}
 
             To uninstall this deployment, close or merge this PR.

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -64,20 +64,3 @@ jobs:
         id: deployment_info
         run: |
           echo ::set-output name=route_host::"$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')"
-
-      - name: Make comment in PR
-        uses: peter-evans/create-or-update-comment@v1
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          issue-number: ${{ github.event.number }}
-          body: |
-            ## 🚀 Preview deployment active
-
-            | | |
-            |-|-|
-            **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
-            **Revision** | ${{ inputs.revision }}
-            **Helm release** | ${{ inputs.namespace }}/${{ inputs.helm_release_name }}
-            **Cluster** | ${{ inputs.openshift_api_url }}
-
-            To uninstall this deployment, close or merge this PR.

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -64,3 +64,20 @@ jobs:
         id: deployment_info
         run: |
           echo ::set-output name=route_host::"$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')"
+
+      - name: Notify on success
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## 🚀 Preview deployment active
+
+            | | |
+            |-|-|
+            **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
+            **Revision** | ${{ inputs.revision }}
+            **Helm release** | ${{ inputs.namespace }}/${{ inputs.helm_release_name }}
+            **Cluster** | ${{ env.OPENSHIFT_API }}
+
+            To uninstall this deployment, close or merge this PR.

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -4,9 +4,6 @@ on:
       namespace:
         type: string
         required: true
-      openshift_api_url:
-        type: string
-        required: true
       helm_release_name:
         type: string
         default: portal
@@ -20,6 +17,9 @@ on:
     secrets:
       openshift_token:
         required: true
+
+env:
+  OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
 
 jobs:
   install:
@@ -46,7 +46,7 @@ jobs:
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         with:
-          openshift_server_url: ${{ inputs.openshift_api_url }}
+          openshift_server_url: ${{ env.OPENSHIFT_API }}
           openshift_token: ${{ secrets.openshift_token }}
           namespace: ${{ inputs.namespace }}
           # We don't have a LE cert yet

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -11,6 +11,9 @@ on:
         type: string
         default: portal
         required: false
+      image_tag:
+        type: string
+        required: true
     secrets:
       openshift_token:
         required: true
@@ -44,10 +47,10 @@ jobs:
           insecure_skip_tls_verify: true
 
       - name: Deploy app
-        run: helmfile --namespace ${{ input.namespace }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
+        run: helmfile --namespace ${{ inputs.namespace }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
         env:
           HELM_RELEASE_NAME: ${{ inputs.helm_release_name }}
-          IMG_TAG: ${{ env.IMG_TAG }}
+          IMG_TAG: ${{ inputs.image_tag }}
           #GIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Gather deployment status
@@ -69,6 +72,6 @@ jobs:
             **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
             **Revision** | ${{ github.event.pull_request.head.sha }}
             **Helm release** | ${{ inputs.namespace }}/${{ inputs.helm_release_name }}
-            **Cluster** | ${{ env.OPENSHIFT_API }}
+            **Cluster** | ${{ inputs.openshift_api_url }}
 
             To uninstall this deployment, close or merge this PR.

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -1,0 +1,70 @@
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        type: string
+        required: true
+      openshift_api_url:
+        type: string
+        required: true
+    secrets:
+      openshift_token:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deployment_info.outputs.route_host }}
+    steps:
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v0.9.0
+        with:
+          helm-version: v3.7.1
+          helmfile-version: v0.142.0
+          install-kubectl: false
+
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
+      - name: Authenticate and set context
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ inputs.openshift_api_url }}
+          openshift_token: ${{ secrets.openshift_token }}
+          namespace: ${{ inputs.namespace }}
+          # We don't have a LE cert yet
+          insecure_skip_tls_verify: true
+
+      - name: Deploy app
+        run: helmfile --namespace ${{ env.NAMESPACE }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
+        env:
+          HELM_RELEASE_NAME: ${{ env.HELM_RELEASE_NAME }}
+          IMG_TAG: ${{ env.IMG_TAG }}
+          #GIT_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Gather deployment status
+        if: ${{ github.event_name == 'pull_request' }}
+        id: deployment_info
+        run: |
+          echo ::set-output name=route_host::"$(oc -n ${{ env.NAMESPACE }} get route ${{ env.HELM_RELEASE_NAME }} -o jsonpath='{.spec.host}')"
+
+      - name: Make comment in PR
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## 🚀 Preview deployment active
+
+            | | |
+            |-|-|
+            **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
+            **Revision** | ${{ github.event.pull_request.head.sha }}
+            **Helm release** | ${{ env.NAMESPACE }}/${{ env.HELM_RELEASE_NAME }}
+            **Cluster** | ${{ env.OPENSHIFT_API }}
+
+            To uninstall this deployment, close or merge this PR.

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -14,6 +14,9 @@ on:
       image_tag:
         type: string
         required: true
+      revision:
+        type: string
+        required: true
     secrets:
       openshift_token:
         required: true
@@ -33,6 +36,7 @@ jobs:
           helm-version: v3.7.1
           helmfile-version: v0.142.0
           install-kubectl: false
+          additional-helm-plugins: https://github.com/aslafy-z/helm-git --version 0.11.1
 
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -49,11 +53,11 @@ jobs:
           insecure_skip_tls_verify: true
 
       - name: Deploy app
-        run: helmfile --namespace ${{ inputs.namespace }} --file deployment/helmfile.yaml -e preview diff # diff for now, but should be `apply --wait`
+        run: helmfile --namespace ${{ inputs.namespace }} --file deployment/helmfile.yaml -e preview apply --wait
         env:
           HELM_RELEASE_NAME: ${{ inputs.helm_release_name }}
           IMG_TAG: ${{ inputs.image_tag }}
-          #GIT_SHA: ${{ github.event.pull_request.head.sha }}
+          GIT_SHA: ${{ inputs.revision }}
 
       - name: Gather deployment status
         if: ${{ github.event_name == 'pull_request' }}
@@ -72,7 +76,7 @@ jobs:
             | | |
             |-|-|
             **App URL** | https://${{ steps.deployment_info.outputs.route_host }}
-            **Revision** | ${{ github.event.pull_request.head.sha }}
+            **Revision** | ${{ inputs.revision }}
             **Helm release** | ${{ inputs.namespace }}/${{ inputs.helm_release_name }}
             **Cluster** | ${{ inputs.openshift_api_url }}
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,27 @@ docker compose exec auth /opt/jboss/keycloak/bin/standalone.sh \
 ## Configuration
 
 The APPUiO Cloud Portal can be configured with the `config.json` file which is located in the `src` directory.
+
+
+## Deploy to OpenShift
+
+Setup the project and deploy user
+
+```bash
+nstest=appuio-cloud-preview
+sa=cloud-portal-deployer
+
+oc new-project $nstest
+
+oc -n $nstest create sa $sa
+
+# Allow the deployer user to manage deployments in test namespace
+oc -n $nstest policy add-role-to-user admin -z $sa --rolebinding-name admin
+oc -n $nstest policy add-role-to-user system:image-pusher -z $sa
+echo
+
+# Get SA token
+oc -n $nstest sa get-token $sa
+```
+
+Now, put the token into GitHub's Secrets

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The APPUiO Cloud Portal can be configured with the `config.json` file which is l
 Setup the project and deploy user
 
 ```bash
-nstest=appuio-cloud-preview
+nstest=appuio-control-api-preview
 sa=cloud-portal-deployer
 
 oc new-project $nstest

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -13,12 +13,12 @@ helmDefaults:
 releases:
   - name: {{ env "HELM_RELEASE_NAME" | default "portal" }}
     chart: appuio/cloud-portal
-    createNamespace: false
     missingFileHandler: Warn
     values:
       - {{ .Environment.Name }}.yaml
       - image:
           tag: {{ trimPrefix "refs/tags/" (requiredEnv "IMG_TAG") }}
+          repository: {{ .Namespace }}/cloud-portal
       - fullnameOverride: {{ env "HELM_RELEASE_NAME" | default "portal" }}
       - podAnnotations:
           app.kubernetes.io/git-shasum: {{ env "GIT_SHA" | default "GIT_SHA" }}

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -13,6 +13,7 @@ helmDefaults:
 releases:
   - name: {{ env "HELM_RELEASE_NAME" | default "portal" }}
     chart: appuio/cloud-portal
+    createNamespace: false
     missingFileHandler: Warn
     values:
       - {{ .Environment.Name }}.yaml

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -1,0 +1,24 @@
+repositories:
+  - name: appuio
+    #url: https://charts.appuio.ch
+    # If testing out a feature branch, use the Git url:
+    url: git+https://github.com/appuio/charts@appuio/cloud-portal?ref=cloud-portal
+
+environments:
+  preview: {}
+
+helmDefaults:
+  historyMax: 3
+
+releases:
+  - name: {{ env "HELM_RELEASE_NAME" | default "portal" }}
+    chart: appuio/cloud-portal
+    createNamespace: false
+    missingFileHandler: Warn
+    values:
+      - {{ .Environment.Name }}.yaml
+      - image:
+          tag: {{ trimPrefix "refs/tags/" (requiredEnv "IMG_TAG") }}
+      - fullnameOverride: {{ env "HELM_RELEASE_NAME" | default "portal" }}
+      - podAnnotations:
+          app.kubernetes.io/git-shasum: {{ env "GIT_SHA" | default "GIT_SHA" }}

--- a/deployment/preview.yaml
+++ b/deployment/preview.yaml
@@ -2,5 +2,4 @@ route:
   enabled: true
 image:
   registry: image-registry.openshift-image-registry.svc:5000
-  repository: appuio-cloud-preview/cloud-portal
   pullPolicy: Always

--- a/deployment/preview.yaml
+++ b/deployment/preview.yaml
@@ -1,0 +1,6 @@
+route:
+  enabled: true
+image:
+  registry: image-registry.openshift-image-registry.svc:5000
+  repository: appuio-cloud-preview/cloud-portal
+  pullPolicy: Always


### PR DESCRIPTION
## Summary

* Adds GitHub workflows so that each Pull request (except labelled with `dependency`) will be deployed in a preview environment.
* If the deployment was successful, a comment is added to the PR with a direct link to the frontend URL.
* When the PR is closed, the deployment is removed again.

See #31 

## Checklist

- [ ] Reusable workflow: set branch name to master
- [x] Check if oc installation workaround can be reverted
- [ ] Change namespace name
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
