### PR TITLE
Automatic deployment to integration

### DIFF
--- a/.github/keycloak-redirect-url.sh
+++ b/.github/keycloak-redirect-url.sh
@@ -29,10 +29,10 @@ json_resp_client=$(curl -sS --fail ${clientUrl} -H "Content-Type: application/js
 
 if [ "${ACTION}" = "remove" ]; then
   echo "* Removing '${REDIRECT_URI}' from Client config '${editClientId}'"
-  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.- ["'${REDIRECT_URI}'"] | unique)')
+  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.- ["'${REDIRECT_URI}'/*"] | unique) | .webOrigins |= (.- ["'${REDIRECT_URI}'"] | unique)')
 else
   echo "* Adding '${REDIRECT_URI}' to Client config '${editClientId}'"
-  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.+ ["'${REDIRECT_URI}'"] | unique)')
+  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.+ ["'${REDIRECT_URI}'/*"] | unique) | .webOrigins |= (.+ ["'${REDIRECT_URI}'"] | unique)')
 fi
 
 curl -sS --fail ${clientUrl} -H "Content-Type: application/json" -H "Authorization: bearer ${access_token}" -X PUT --data "${json_req_update}"

--- a/.github/keycloak-redirect-url.sh
+++ b/.github/keycloak-redirect-url.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE_URL=https://id.dev.appuio.cloud
+
+USER=$1
+PASSWORD=$2
+REDIRECT_URI=$3
+
+ACTION=$4
+
+loginRealm=master
+
+editRealm=appuio-cloud-dev
+# The client ID has to be the UUID
+editClientId=a4d5a5cb-81ff-4532-9b25-d2d4242d23e2
+
+loginUrl="${BASE_URL}/auth/realms/${loginRealm}/protocol/openid-connect/token"
+clientUrl="${BASE_URL}/auth/admin/realms/${editRealm}/clients/${editClientId}"
+
+
+echo "* Logging in to ${loginRealm}"
+json_resp_login=$(curl -sS --fail --data "username=${USER}&password=${PASSWORD}&grant_type=password&client_id=admin-cli" "${loginUrl}")
+access_token=$(echo "${json_resp_login}" | jq -r '.access_token')
+
+echo "* Retrieving Client config '${editClientId}'"
+json_resp_client=$(curl -sS --fail ${clientUrl} -H "Content-Type: application/json" -H "Authorization: bearer ${access_token}")
+
+if [ "${ACTION}" = "remove" ]; then
+  echo "* Removing '${REDIRECT_URI}' from Client config '${editClientId}'"
+  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.- ["'${REDIRECT_URI}'"] | unique)')
+else
+  echo "* Adding '${REDIRECT_URI}' to Client config '${editClientId}'"
+  json_req_update=$(echo ${json_resp_client} | jq -c '.redirectUris |= (.+ ["'${REDIRECT_URI}'"] | unique)')
+fi
+
+curl -sS --fail ${clientUrl} -H "Content-Type: application/json" -H "Authorization: bearer ${access_token}" -X PUT --data "${json_req_update}"

--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   uninstall:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    if: ${{ !contains(github.ref, 'refs/heads/renovate/') }}
     environment: preview
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -64,6 +64,9 @@ jobs:
             **Helm release** | ${{ env.NAMESPACE }}/${{ env.HELM_RELEASE_NAME }}
             **Cluster** | ${{ env.OPENSHIFT_API }}
 
+      - name: Remove route URL from Keycloak client
+        run: ./github/keycloak-redirect-url.sh "${{ secrets.KEYCLOAK_USER }}" "${{ secrets.KEYCLOAK_PASSWORD }}" "https://${{ steps.deployment_info.outputs.route_host }}/*" remove
+
       - name: Notify on failure
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ failure() }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,63 @@
+name: Master
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: registry.cloudscale-lpg-2.appuio.cloud
+  NAMESPACE: appuio-control-api-integration
+  IMAGE_NAME: cloud-portal
+
+jobs:
+
+  build:
+    uses: appuio/cloud-portal/.github/workflows/template-build.yaml@master
+
+  docker:
+    runs-on: ubuntu-latest
+    environment: integration
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # by default, it creates the `:pr-#` tag in pull requests and branch name on `master`
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE}}/${{ env.IMAGE_NAME }}
+
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.OPENSHIFT_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@master
+    with:
+      namespace: appuio-control-api-integration
+      image_tag: master
+      revision: ${{ github.sha }}
+      environment: integration
+    secrets:
+      openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+    needs:
+      - build
+      - docker

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,7 +49,7 @@ jobs:
 
   deploy:
     # Don't deploy with Renovate PRs
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency') }}
+    if: ${{ !contains(github.ref, 'refs/heads/renovate/') }}
     uses: appuio/cloud-portal/.github/workflows/template-deploy.yaml@master
     with:
       namespace: appuio-control-api-preview

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -58,6 +58,8 @@ jobs:
       revision: ${{ github.event.pull_request.head.sha }}
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+      keycloak_password: ${{ secrets.KEYCLOAK_PASSWORD }}
+      keycloak_user: ${{ secrets.KEYCLOAK_USER }}
     needs:
       - build
       - docker

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Add route URL to Keycloak client
         if: ${{ github.event_name == 'pull_request' }}
-        run: .github/keycloak-redirect-url.sh "${{ secrets.keycloak_user }}" "${{ secrets.keycloak_password }}" "https://${{ steps.deployment_info.outputs.route_host }}/*"
+        run: .github/keycloak-redirect-url.sh "${{ secrets.keycloak_user }}" "${{ secrets.keycloak_password }}" "https://${{ steps.deployment_info.outputs.route_host }}"
 
       - name: Notify on success
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -14,6 +14,10 @@ on:
       revision:
         type: string
         required: true
+      environment:
+        type: string
+        required: false
+        default: preview
     secrets:
       openshift_token:
         required: true
@@ -25,7 +29,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     environment:
-      name: preview
+      name: ${{ inputs.environment }}
       url: https://${{ steps.deployment_info.outputs.route_host }}
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +57,7 @@ jobs:
           insecure_skip_tls_verify: true
 
       - name: Deploy app
-        run: helmfile --namespace ${{ inputs.namespace }} --file deployment/helmfile.yaml -e preview apply --wait
+        run: helmfile --namespace ${{ inputs.namespace }} --file deployment/helmfile.yaml -e ${{ inputs.environment }} apply --wait
         env:
           HELM_RELEASE_NAME: ${{ inputs.helm_release_name }}
           IMG_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -21,6 +21,10 @@ on:
     secrets:
       openshift_token:
         required: true
+      keycloak_user:
+        required: false
+      keycloak_password:
+        required: false
 
 env:
   OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
@@ -68,6 +72,10 @@ jobs:
         id: deployment_info
         run: |
           echo ::set-output name=route_host::"$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')"
+
+      - name: Add route URL to Keycloak client
+        if: ${{ github.event_name == 'pull_request' }}
+        run: .github/keycloak-redirect-url.sh "${{ secrets.keycloak_user }}" "${{ secrets.keycloak_password }}" "https://${{ steps.deployment_info.outputs.route_host }}/*"
 
       - name: Notify on success
         uses: peter-evans/create-or-update-comment@v1

--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ oc -n $nstest sa get-token $sa
 ```
 
 Now, put the token into GitHub's Secrets
+
+## Use existing Keycloak in preview deployments
+
+A GitHub action workflows dynamically registers the redirect URL in an existing Keycloak instance via API.
+
+1. Create a new User in master realm
+1. Set a secure password
+1. In the role mappings, select `appuio-cloud-dev-realm` in the "Client Roles" dropdown.
+   Add `manage-clients`.
+1. Create a new Client in the target realm (e.g. `appuio-control-api`)
+1. When editing the client, the URL shows the UUID of the client.
+   Copy this value and set it in `.github/keycloak-redirect-url.sh`.
+1. Update the `KEYCLOAK_USER` and `KEYCLOAK_PASSWORD` secrets in GitHub environment `preview` with the values in the first steps.

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -7,21 +7,24 @@ environments:
 
 repositories:
   - name: appuio
-    url: {{ getOrNil "repoUrl" .Values | default "https://charts.appuio.ch" }}
+    url: "{{ getOrNil "repoUrl" .Values | default "https://charts.appuio.ch" }}"
 
 helmDefaults:
   historyMax: 3
 
 releases:
-  - name: {{ env "HELM_RELEASE_NAME" | default "portal" }}
+  - name: "{{ env "HELM_RELEASE_NAME" | default "portal" }}"
     chart: appuio/cloud-portal
     createNamespace: false
     missingFileHandler: Warn
     values:
-      - {{ .Environment.Name }}.yaml
+      - "{{ .Environment.Name }}.yaml"
       - image:
           tag: {{ trimPrefix "refs/tags/" (requiredEnv "IMG_TAG") }}
-          repository: {{ .Namespace }}/cloud-portal
+          repository: "{{ .Namespace }}/cloud-portal"
       - fullnameOverride: {{ env "HELM_RELEASE_NAME" | default "portal" }}
       - podAnnotations:
           app.kubernetes.io/git-shasum: {{ env "GIT_SHA" | default "GIT_SHA" }}
+      - portal:
+          config:
+            version: {{ env "GIT_SHA" | default "GIT_SHA" }}

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -15,6 +15,7 @@ helmDefaults:
 releases:
   - name: "{{ env "HELM_RELEASE_NAME" | default "portal" }}"
     chart: appuio/cloud-portal
+    version: v0.1.0
     createNamespace: false
     missingFileHandler: Warn
     values:

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -6,6 +6,7 @@ repositories:
 
 environments:
   preview: {}
+  integration: {}
 
 helmDefaults:
   historyMax: 3

--- a/deployment/helmfile.yaml
+++ b/deployment/helmfile.yaml
@@ -1,12 +1,13 @@
+environments:
+  preview:
+    values:
+      # If testing out a feature branch of the Helm chart, uncomment the Git url:
+      - repoUrl: git+https://github.com/appuio/charts@appuio/cloud-portal?ref=cloud-portal
+  integration: {}
+
 repositories:
   - name: appuio
-    #url: https://charts.appuio.ch
-    # If testing out a feature branch, use the Git url:
-    url: git+https://github.com/appuio/charts@appuio/cloud-portal?ref=cloud-portal
-
-environments:
-  preview: {}
-  integration: {}
+    url: {{ getOrNil "repoUrl" .Values | default "https://charts.appuio.ch" }}
 
 helmDefaults:
   historyMax: 3

--- a/deployment/integration.yaml
+++ b/deployment/integration.yaml
@@ -1,0 +1,6 @@
+route:
+  enabled: true
+  host: cloud-portal-integration.apps.cloudscale-lpg-2.appuio.cloud
+image:
+  registry: image-registry.openshift-image-registry.svc:5000
+  pullPolicy: Always

--- a/deployment/integration.yaml
+++ b/deployment/integration.yaml
@@ -4,3 +4,7 @@ route:
 image:
   registry: image-registry.openshift-image-registry.svc:5000
   pullPolicy: Always
+portal:
+  config:
+    issuer: https://id.appuio.cloud/auth/realms/appuio-cloud
+    clientId: appuio-control-api

--- a/deployment/preview.yaml
+++ b/deployment/preview.yaml
@@ -3,3 +3,7 @@ route:
 image:
   registry: image-registry.openshift-image-registry.svc:5000
   pullPolicy: Always
+portal:
+  config:
+    issuer: https://id.dev.appuio.cloud/auth/realms/appuio-cloud-dev
+    clientId: appuio-control-api


### PR DESCRIPTION
## Summary

* Adds automatic deployment (similar to previews) to integration environment
* A `master` image tag is pushed to OpenShift with each push to `master` branch.

No uninstallation workflow needed since this is expected to be long-running.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.
- [x] Rebase after #39 

Before merging
- [ ] Set reusable workflow version back to master
- [ ] Merge https://github.com/appuio/charts/pull/380
- [ ] Use charts.appuio.ch as Helm repo for future previews

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
