### PR TITLE
Add `glitchTipDsn` secret in integration deploy GitHub action

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -58,6 +58,7 @@ jobs:
       environment: integration
     secrets:
       openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+      glitch_tip_dsn: ${{ secrets.GLITCH_TIP_DSN }}
     needs:
       - build
       - docker


### PR DESCRIPTION
## Summary

Add missing `glitchTipDsn` secret in integration deploy GitHub action. This was missed in #107 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
