### PR TITLE
User can view and edit other users' organization roles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,8 @@
             "allowExpressions": true
           }
         ],
-        "semi": "error"
+        "semi": "error", 
+        "curly": "error"
       },
       "plugins": ["ngrx", "change-detection-strategy", "prettier"]
     },

--- a/cypress/fixtures/role-bindings.ts
+++ b/cypress/fixtures/role-bindings.ts
@@ -1,0 +1,31 @@
+import { UserRef } from '../../src/app/types/team';
+
+import { RoleBindingList } from 'src/app/types/role-bindings';
+
+export interface RoleBindingConfig {
+  namespace: string;
+  roles: { name: string; userRefs: UserRef[] }[];
+}
+
+export function createRoleBindingList(roleBindingConfig: RoleBindingConfig): RoleBindingList {
+  return {
+    kind: 'RoleBindingsList',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    metadata: {
+      resourceVersion: '12345',
+    },
+    items: roleBindingConfig.roles.map((role) => {
+      return {
+        metadata: { name: role.name, namespace: roleBindingConfig.namespace },
+        roleRef: { name: role.name, kind: 'ClusterRole', apiGroup: 'rbac.authorization.k8s.io' },
+        subjects: role.userRefs.map((user) => {
+          return {
+            kind: 'User',
+            apiGroup: 'rbac.authorization.k8s.io',
+            name: `appuio#${user.name}`,
+          };
+        }),
+      };
+    }),
+  };
+}

--- a/cypress/integration/organization-members.spec.ts
+++ b/cypress/integration/organization-members.spec.ts
@@ -1,6 +1,7 @@
 import { createUser } from '../fixtures/user';
 import { organizationListNxtVshn } from '../fixtures/organization';
 import { createOrganizationMembers } from '../fixtures/organization-members';
+import { createRoleBindingList } from 'cypress/fixtures/role-bindings';
 
 describe('Test organization members', () => {
   beforeEach(() => {
@@ -34,11 +35,24 @@ describe('Test organization members', () => {
         userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }],
       }),
     });
+    cy.intercept('GET', 'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings', {
+      body: createRoleBindingList({
+        namespace: 'nxt',
+        roles: [
+          { name: 'control-api:organization-admin', userRefs: [{ name: 'hans.meier' }] },
+          { name: 'control-api:organization-viewer', userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }] },
+        ],
+      }),
+    });
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
     cy.get('.text-3xl').should('contain.text', 'nxt Members');
     cy.get(':nth-child(2) > .p-inputtext').should('have.value', 'hans.meier');
     cy.get(':nth-child(3) > .p-inputtext').should('have.value', 'peter.muster');
+    cy.get(':nth-child(2) > p-multiselect')
+      .should('contain', 'control-api:organization-admin')
+      .and('contain', 'control-api:organization-viewer');
+    cy.get(':nth-child(3) > p-multiselect').should('contain', 'control-api:organization-viewer');
     cy.get('button[type=submit]').should('not.exist');
   });
   it('edit list with two entries', () => {
@@ -57,12 +71,35 @@ describe('Test organization members', () => {
         userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }],
       }),
     });
+    cy.intercept('GET', 'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings', {
+      body: createRoleBindingList({
+        namespace: 'nxt',
+        roles: [
+          { name: 'control-api:organization-admin', userRefs: [{ name: 'hans.meier' }] },
+          { name: 'control-api:organization-viewer', userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }] },
+        ],
+      }),
+    });
     cy.intercept('PUT', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
       body: createOrganizationMembers({
         namespace: 'nxt',
         userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }],
       }),
     }).as('save');
+    cy.intercept(
+      'PUT',
+      'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings/control-api:organization-admin',
+      {
+        body: {},
+      }
+    ).as('save-admin-role');
+    cy.intercept(
+      'PUT',
+      'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings/control-api:organization-viewer',
+      {
+        body: {},
+      }
+    ).as('save-viewer-role');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').should('exist');
     cy.get(':nth-child(3) > .flex-row [title="Edit members"]').should('not.exist');
@@ -71,12 +108,25 @@ describe('Test organization members', () => {
     cy.get(':nth-child(2) > .p-inputtext').should('have.value', 'hans.meier');
     cy.get(':nth-child(3) > .p-inputtext').should('have.value', 'peter.muster');
     cy.get(':nth-child(3) > .p-inputtext').type('{selectall}test');
+    cy.get(':nth-child(3) p-multiselect').click().contains('control-api:organization-admin').click();
     cy.get('button[type=submit]').click();
     cy.get('@save')
       .its('request.body')
       .then((body) => {
         expect(body.spec.userRefs[0].name).to.eq('hans.meier');
         expect(body.spec.userRefs[1].name).to.eq('test');
+      });
+    cy.get('@save-admin-role')
+      .its('request.body')
+      .then((body) => {
+        expect(body.subjects[0].name).to.eq('appuio#hans.meier');
+        expect(body.subjects[1].name).to.eq('appuio#test');
+      });
+    cy.get('@save-viewer-role')
+      .its('request.body')
+      .then((body) => {
+        expect(body.subjects[0].name).to.eq('appuio#hans.meier');
+        expect(body.subjects[1].name).to.eq('appuio#test');
       });
   });
   it('add a new entry', () => {
@@ -95,12 +145,35 @@ describe('Test organization members', () => {
         userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }],
       }),
     });
+    cy.intercept('GET', 'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings', {
+      body: createRoleBindingList({
+        namespace: 'nxt',
+        roles: [
+          { name: 'control-api:organization-admin', userRefs: [{ name: 'hans.meier' }] },
+          { name: 'control-api:organization-viewer', userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }] },
+        ],
+      }),
+    });
     cy.intercept('PUT', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
       body: createOrganizationMembers({
         namespace: 'nxt',
         userRefs: [{ name: 'hans.meier' }, { name: 'peter.muster' }],
       }),
     }).as('save');
+    cy.intercept(
+      'PUT',
+      'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings/control-api:organization-admin',
+      {
+        body: {},
+      }
+    ).as('save-admin-role');
+    cy.intercept(
+      'PUT',
+      'appuio-api/apis/rbac.authorization.k8s.io/v1/namespaces/nxt/rolebindings/control-api:organization-viewer',
+      {
+        body: {},
+      }
+    ).as('save-viewer-role');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
     cy.get('.text-3xl').should('contain.text', 'nxt Members');
@@ -114,6 +187,18 @@ describe('Test organization members', () => {
         expect(body.spec.userRefs[0].name).to.eq('hans.meier');
         expect(body.spec.userRefs[1].name).to.eq('peter.muster');
         expect(body.spec.userRefs[2].name).to.eq('test');
+      });
+    cy.get('@save-admin-role')
+      .its('request.body')
+      .then((body) => {
+        expect(body.subjects[0].name).to.eq('appuio#hans.meier');
+      });
+    cy.get('@save-viewer-role')
+      .its('request.body')
+      .then((body) => {
+        expect(body.subjects[0].name).to.eq('appuio#hans.meier');
+        expect(body.subjects[1].name).to.eq('appuio#peter.muster');
+        expect(body.subjects[2].name).to.eq('appuio#test');
       });
   });
   it('no list permission', () => {

--- a/cypress/integration/organization-members.spec.ts
+++ b/cypress/integration/organization-members.spec.ts
@@ -47,12 +47,15 @@ describe('Test organization members', () => {
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
     cy.get('.text-3xl').should('contain.text', 'nxt Members');
-    cy.get(':nth-child(2) > .p-inputtext').should('have.value', 'hans.meier');
-    cy.get(':nth-child(3) > .p-inputtext').should('have.value', 'peter.muster');
-    cy.get(':nth-child(2) > p-multiselect')
+    cy.get(':nth-child(2) > .p-inputtext').should('have.value', 'hans.meier').and('be.disabled');
+    cy.get(':nth-child(3) > .p-inputtext').should('have.value', 'peter.muster').and('be.disabled');
+    cy.get(':nth-child(2) .p-multiselect')
       .should('contain', 'control-api:organization-admin')
-      .and('contain', 'control-api:organization-viewer');
-    cy.get(':nth-child(3) > p-multiselect').should('contain', 'control-api:organization-viewer');
+      .and('contain', 'control-api:organization-viewer')
+      .and('have.class', 'p-disabled');
+    cy.get(':nth-child(3) .p-multiselect')
+      .should('contain', 'control-api:organization-viewer')
+      .and('have.class', 'p-disabled');
     cy.get('button[type=submit]').should('not.exist');
   });
   it('edit list with two entries', () => {

--- a/src/app/core/kubernetes-client.service.ts
+++ b/src/app/core/kubernetes-client.service.ts
@@ -9,6 +9,7 @@ import { OrganizationMemberList, OrganizationMembers } from '../types/organizati
 import { Team } from '../types/team';
 import { List } from '../types/list';
 import { User } from '../types/user';
+import { RoleBindingList } from '../types/role-bindings';
 
 @Injectable({
   providedIn: 'root',
@@ -18,6 +19,7 @@ export class KubernetesClientService {
   private readonly zonesApi = `${this.apiPrefix}/apis/appuio.io/v1/zones`;
   private readonly usersApi = `${this.apiPrefix}/apis/appuio.io/v1/users`;
   private readonly organizationsApi = `${this.apiPrefix}/apis/organization.appuio.io/v1/organizations`;
+  private readonly authApi = `${this.apiPrefix}/apis/rbac.authorization.k8s.io/v1/`;
 
   constructor(private httpClient: HttpClient) {}
 
@@ -90,6 +92,10 @@ export class KubernetesClientService {
 
   updateOrganization(organization: Organization): Observable<Organization> {
     return this.httpClient.put<Organization>(`${this.organizationsApi}/${organization.metadata.name}`, organization);
+  }
+
+  getRoleBindings(namespace: string): Observable<RoleBindingList> {
+    return this.httpClient.get<RoleBindingList>(`${this.authApi}/namespaces/${namespace}/rolebindings`);
   }
 
   getOrganizationsPermission(): Observable<Verb[]> {

--- a/src/app/core/kubernetes-client.service.ts
+++ b/src/app/core/kubernetes-client.service.ts
@@ -9,7 +9,7 @@ import { OrganizationMemberList, OrganizationMembers } from '../types/organizati
 import { Team } from '../types/team';
 import { List } from '../types/list';
 import { User } from '../types/user';
-import { RoleBindingList } from '../types/role-bindings';
+import { RoleBindingList, RoleBindings } from '../types/role-bindings';
 
 @Injectable({
   providedIn: 'root',
@@ -19,7 +19,7 @@ export class KubernetesClientService {
   private readonly zonesApi = `${this.apiPrefix}/apis/appuio.io/v1/zones`;
   private readonly usersApi = `${this.apiPrefix}/apis/appuio.io/v1/users`;
   private readonly organizationsApi = `${this.apiPrefix}/apis/organization.appuio.io/v1/organizations`;
-  private readonly authApi = `${this.apiPrefix}/apis/rbac.authorization.k8s.io/v1/`;
+  private readonly authApi = `${this.apiPrefix}/apis/rbac.authorization.k8s.io/v1`;
 
   constructor(private httpClient: HttpClient) {}
 
@@ -96,6 +96,13 @@ export class KubernetesClientService {
 
   getRoleBindings(namespace: string): Observable<RoleBindingList> {
     return this.httpClient.get<RoleBindingList>(`${this.authApi}/namespaces/${namespace}/rolebindings`);
+  }
+
+  updateRoleBinding(roleBinding: RoleBindings): Observable<RoleBindings> {
+    return this.httpClient.put<RoleBindings>(
+      `${this.authApi}/namespaces/${roleBinding.metadata.namespace}/rolebindings/${roleBinding.metadata.name}`,
+      roleBinding
+    );
   }
 
   getOrganizationsPermission(): Observable<Verb[]> {

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.html
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.html
@@ -1,5 +1,5 @@
 <p-dialog
-  (onHide)="firstTimeLoginDialogHide()"
+  (onHide)="onHide()"
   [(visible)]="showFirstLoginDialog"
   [draggable]="false"
   [modal]="true"
@@ -14,8 +14,8 @@
     </div>
     <div class="text-700 line-height-3 pl-4 w-8">
       <p class="mt-0" i18n>
-        Unfortunately, you do not yet belong to an organization. You can either join an existing organization or create a new
-        one.
+        Unfortunately, you do not yet belong to an organization. You can either join an existing organization or create
+        a new one.
       </p>
 
       <p i18n>

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
@@ -23,14 +23,10 @@ export class FirstTimeLoginDialogComponent implements OnInit {
   faSitemap = faSitemap;
   faAdd = faAdd;
   hideFirstTimeLoginDialogControl = new FormControl(false);
-  nextAddOrganisation = false;
-  nextJoinOrganisation = false;
+  nextAction?: 'join' | 'add';
 
   constructor(
-    private oauthService: OAuthService,
-    private store: Store,
     private router: Router,
-    private appConfigService: AppConfigService,
     private changeDetectorRef: ChangeDetectorRef,
     private kubernetesClientService: KubernetesClientService,
     private identityService: IdentityService
@@ -68,19 +64,19 @@ export class FirstTimeLoginDialogComponent implements OnInit {
 
   addOrganization(): void {
     this.showFirstLoginDialog = false;
-    this.nextAddOrganisation = true;
+    this.nextAction = 'add';
   }
 
   joinOrganization(): void {
     this.showFirstLoginDialog = false;
-    this.nextJoinOrganisation = true;
+    this.nextAction = 'join';
   }
 
   onHide(): void {
     this.firstTimeLoginDialogHide();
-    if (this.nextAddOrganisation) {
+    if (this.nextAction === 'add') {
       void this.router.navigate(['organizations/$new']);
-    } else if (this.nextJoinOrganisation) {
+    } else if (this.nextAction === 'join') {
       void this.router.navigate(['organizations'], { queryParams: { showJoinDialog: true } });
     }
   }

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
@@ -23,6 +23,8 @@ export class FirstTimeLoginDialogComponent implements OnInit {
   faSitemap = faSitemap;
   faAdd = faAdd;
   hideFirstTimeLoginDialogControl = new FormControl(false);
+  nextAddOrganisation = false;
+  nextJoinOrganisation = false;
 
   constructor(
     private oauthService: OAuthService,
@@ -66,12 +68,21 @@ export class FirstTimeLoginDialogComponent implements OnInit {
 
   addOrganization(): void {
     this.showFirstLoginDialog = false;
-    void this.router.navigate(['organizations/$new']);
+    this.nextAddOrganisation = true;
   }
 
   joinOrganization(): void {
     this.showFirstLoginDialog = false;
-    void this.router.navigate(['organizations'], { queryParams: { showJoinDialog: true } });
+    this.nextJoinOrganisation = true;
+  }
+
+  onHide(): void {
+    this.firstTimeLoginDialogHide();
+    if (this.nextAddOrganisation) {
+      void this.router.navigate(['organizations/$new']);
+    } else if (this.nextJoinOrganisation) {
+      void this.router.navigate(['organizations'], { queryParams: { showJoinDialog: true } });
+    }
   }
 
   firstTimeLoginDialogHide(): void {

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.html
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.html
@@ -28,7 +28,7 @@
         <p-multiSelect
           formControlName="selectedRoles"
           class="col-8"
-          [options]="allRoles"
+          [options]="allRoleNames"
           display="chip"
           defaultLabel="Select Roles"
           i18n-defaultLabel></p-multiSelect>

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.html
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.html
@@ -16,45 +16,47 @@
           severity="info"
           text="List all user names that should have access to this organization."></p-message>
       </div>
-      <div class="grid mt-3">
-        <label class="col-3" i18n>Name</label>
-        <label class="col-8" i18n>Roles</label>
-      </div>
-      <div
-        *ngFor="let control of this.userRefs.controls; let i = index; let last = last"
-        class="grid formgrid mb-3"
-        [formGroup]="$any(control)">
-        <input formControlName="userName" class="col-3" pInputText tabindex="0" type="text" />
-        <p-multiSelect
-          formControlName="selectedRoles"
-          class="col-8"
-          [options]="allRoleNames"
-          display="chip"
-          defaultLabel="Select Roles"
-          i18n-defaultLabel></p-multiSelect>
+      <div class="max-w-1200px">
+        <div class="grid mt-3">
+          <label class="col-3 ml-2" i18n>Name</label>
+          <label class="col-7" i18n>Roles</label>
+        </div>
+        <div
+          *ngFor="let control of this.userRefs.controls; let i = index; let last = last"
+          class="grid formgrid mb-3"
+          [formGroup]="$any(control)">
+          <input formControlName="userName" class="field col-3 ml-2" pInputText tabindex="0" type="text" />
+          <p-multiSelect
+            formControlName="selectedRoles"
+            class="field col-7"
+            [options]="allRoleNames"
+            display="chip"
+            defaultLabel="Select Roles"
+            i18n-defaultLabel></p-multiSelect>
 
-        <button
-          (click)="removeFormControl(i)"
-          *ngIf="!last && editPermission; else noButton"
-          class="col-1 p-button-icon-only ml-3"
-          i18n-title
-          pButton
-          pRipple
-          tabindex="1"
-          title="Remove"
-          type="button">
-          <fa-icon [icon]="faClose"></fa-icon>
-        </button>
-        <ng-template #noButton>
-          <div *ngIf="editPermission" class="ml-3 w-3rem"></div>
-        </ng-template>
-      </div>
+          <button
+            (click)="removeFormControl(i)"
+            *ngIf="!last && editPermission; else noButton"
+            class="col-1 field p-button-icon-only ml-3"
+            i18n-title
+            pButton
+            pRipple
+            tabindex="1"
+            title="Remove"
+            type="button">
+            <fa-icon [icon]="faClose"></fa-icon>
+          </button>
+          <ng-template #noButton>
+            <div *ngIf="editPermission" class="ml-3 w-3rem"></div>
+          </ng-template>
+        </div>
 
-      <div *ngIf="editPermission">
-        <button [disabled]="form.invalid" [loading]="saving" class="w-auto mt-3" pButton pRipple type="submit">
-          <fa-icon [icon]="faSave" class="pr-2"></fa-icon>
-          <span class="pr-2" i18n>Save</span>
-        </button>
+        <div *ngIf="editPermission">
+          <button [disabled]="form.invalid" [loading]="saving" class="w-auto mt-3" pButton pRipple type="submit">
+            <fa-icon [icon]="faSave" class="pr-2"></fa-icon>
+            <span class="pr-2" i18n>Save</span>
+          </button>
+        </div>
       </div>
     </form>
   </div>

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.html
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.html
@@ -16,12 +16,27 @@
           severity="info"
           text="List all user names that should have access to this organization."></p-message>
       </div>
-      <div *ngFor="let control of this.userRefs.controls; let i = index; let last = last" class="flex-auto flex mt-3">
-        <input [formControl]="$any(control)" class="flex-auto" pInputText tabindex="0" type="text" />
+      <div class="grid mt-3">
+        <label class="col-3" i18n>Name</label>
+        <label class="col-8" i18n>Roles</label>
+      </div>
+      <div
+        *ngFor="let control of this.userRefs.controls; let i = index; let last = last"
+        class="grid formgrid mb-3"
+        [formGroup]="$any(control)">
+        <input formControlName="userName" class="col-3" pInputText tabindex="0" type="text" />
+        <p-multiSelect
+          formControlName="selectedRoles"
+          class="col-8"
+          [options]="allRoles"
+          display="chip"
+          defaultLabel="Select Roles"
+          i18n-defaultLabel></p-multiSelect>
+
         <button
           (click)="removeFormControl(i)"
           *ngIf="!last && editPermission; else noButton"
-          class="p-button-icon-only ml-3"
+          class="col-1 p-button-icon-only ml-3"
           i18n-title
           pButton
           pRipple

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.scss
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.scss
@@ -1,0 +1,4 @@
+::ng-deep p-multiselect .p-multiselect-label{
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.scss
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.scss
@@ -1,4 +1,13 @@
-::ng-deep p-multiselect .p-multiselect-label{
-    display: flex;
-    flex-wrap: wrap;
+::ng-deep p-multiselect {
+    .p-multiselect-label {
+        display: flex;
+        flex-wrap: wrap;
+    }
+    .p-multiselect {
+        width: 100%;
+    }
+}
+
+.max-w-1200px {
+    max-width: 1200px;
 }

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -15,6 +15,7 @@ import { MessageService } from 'primeng/api';
 })
 export class OrganizationMembersEditComponent implements OnInit {
   organizationMembers!: OrganizationMembers;
+  usersRoles!: Record<string, string[]>;
   faClose = faClose;
   faSave = faSave;
   saving = false;
@@ -35,7 +36,10 @@ export class OrganizationMembersEditComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.activatedRoute.data.subscribe(({ organizationMembers }) => (this.organizationMembers = organizationMembers));
+    this.activatedRoute.data.subscribe(({ organizationMembers, usersRoles }) => {
+      this.organizationMembers = organizationMembers;
+      this.usersRoles = usersRoles;
+    });
     this.editPermission = this.organizationMembers.editMembers ?? false;
     const members = this.userRefs;
     this.organizationMembers.spec.userRefs?.forEach((userRef) => {

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -52,7 +52,10 @@ export class OrganizationMembersEditComponent implements OnInit {
       members.push(
         new FormGroup({
           userName: new FormControl({ value: userRef.name, disabled: !this.editPermission }, Validators.required),
-          selectedRoles: new FormControl(userRoles[`${this.userNamePrefix}${userRef.name}`]),
+          selectedRoles: new FormControl({
+            value: userRoles[`${this.userNamePrefix}${userRef.name}`],
+            disabled: !this.editPermission,
+          }),
         })
       );
     });

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -25,6 +25,8 @@ export class OrganizationMembersEditComponent implements OnInit {
   });
   editPermission = false;
 
+  // list of cluster roles that can be assigned by user - currently hard-coded as there's nothing
+  // clearly identifying these (e.g. tag or special field)
   readonly allRoleNames = ['control-api:organization-admin', 'control-api:organization-viewer'];
   readonly newUserDefaultRoles = ['control-api:organization-viewer'];
   readonly userNamePrefix = 'appuio#';
@@ -83,7 +85,9 @@ export class OrganizationMembersEditComponent implements OnInit {
     const userRoles: Record<string, string[]> = {};
     this.roleBindings.items.forEach((item) => {
       item.subjects.forEach((subj) => {
-        if (!userRoles[subj.name]) userRoles[subj.name] = [];
+        if (!userRoles[subj.name]) {
+          userRoles[subj.name] = [];
+        }
         userRoles[subj.name].push(item.roleRef.name);
       });
     });
@@ -98,7 +102,9 @@ export class OrganizationMembersEditComponent implements OnInit {
     const rolesToSubjects: Record<string, string[]> = {};
     this.form.value.userRefs.forEach((userDetails: { userName: string; selectedRoles: string[] }) => {
       userDetails.selectedRoles?.forEach((role) => {
-        if (!rolesToSubjects[role]) rolesToSubjects[role] = [];
+        if (!rolesToSubjects[role]) {
+          rolesToSubjects[role] = [];
+        }
         rolesToSubjects[role].push(userDetails.userName);
       });
     });

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -23,6 +23,8 @@ export class OrganizationMembersEditComponent implements OnInit {
     userRefs: new FormArray([]),
   });
   editPermission = false;
+  //TODO get all available roles from API
+  allRoles = ['control-api:organization-admin', 'control-api:organization-viewer'];
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -43,7 +45,12 @@ export class OrganizationMembersEditComponent implements OnInit {
     this.editPermission = this.organizationMembers.editMembers ?? false;
     const members = this.userRefs;
     this.organizationMembers.spec.userRefs?.forEach((userRef) => {
-      members.push(new FormControl({ value: userRef.name, disabled: !this.editPermission }, Validators.required));
+      members.push(
+        new FormGroup({
+          userName: new FormControl({ value: userRef.name, disabled: !this.editPermission }, Validators.required),
+          selectedRoles: new FormControl(this.usersRoles[`appuio#${userRef.name}`]),
+        })
+      );
     });
     if (this.editPermission) {
       this.addEmptyFormControl();
@@ -56,7 +63,11 @@ export class OrganizationMembersEditComponent implements OnInit {
       emptyFormControl.addValidators(Validators.required);
       this.addEmptyFormControl();
     });
-    this.userRefs.push(emptyFormControl);
+    const emptyFormGroup = new FormGroup({
+      userName: emptyFormControl,
+      selectedRoles: new FormControl([]),
+    });
+    this.userRefs.push(emptyFormGroup);
   }
 
   save(): void {

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -26,6 +26,7 @@ export class OrganizationMembersEditComponent implements OnInit {
   editPermission = false;
 
   readonly allRoleNames = ['control-api:organization-admin', 'control-api:organization-viewer'];
+  readonly newUserDefaultRoles = ['control-api:organization-viewer'];
   readonly userNamePrefix = 'appuio#';
 
   constructor(
@@ -64,11 +65,13 @@ export class OrganizationMembersEditComponent implements OnInit {
     const emptyFormControl = new FormControl();
     emptyFormControl.valueChanges.pipe(take(1)).subscribe(() => {
       emptyFormControl.addValidators(Validators.required);
+      emptyRoleDropdown.setValue(this.newUserDefaultRoles);
       this.addEmptyFormControl();
     });
+    const emptyRoleDropdown = new FormControl([]);
     const emptyFormGroup = new FormGroup({
       userName: emptyFormControl,
-      selectedRoles: new FormControl([]),
+      selectedRoles: emptyRoleDropdown,
     });
     this.userRefs.push(emptyFormGroup);
   }

--- a/src/app/organizations/organizations-routing.module.ts
+++ b/src/app/organizations/organizations-routing.module.ts
@@ -5,6 +5,7 @@ import { OrganizationEditComponent } from './organization-edit/organization-edit
 import { PermissionGuard } from '../permission.guard';
 import { OrganizationMembersEditComponent } from './organization-members-edit/organization-members-edit.component';
 import { OrganizationMembersResolver } from './organization-members-edit/organization-members.resolver';
+import { UsersRolesResolver } from './users-roles.resolver';
 
 const routes: Routes = [
   {
@@ -24,7 +25,7 @@ const routes: Routes = [
   {
     path: ':name/members',
     component: OrganizationMembersEditComponent,
-    resolve: { organizationMembers: OrganizationMembersResolver },
+    resolve: { organizationMembers: OrganizationMembersResolver, usersRoles: UsersRolesResolver },
   },
 ];
 

--- a/src/app/organizations/organizations-routing.module.ts
+++ b/src/app/organizations/organizations-routing.module.ts
@@ -25,7 +25,7 @@ const routes: Routes = [
   {
     path: ':name/members',
     component: OrganizationMembersEditComponent,
-    resolve: { organizationMembers: OrganizationMembersResolver, usersRoles: UsersRolesResolver },
+    resolve: { organizationMembers: OrganizationMembersResolver, roleBindings: UsersRolesResolver },
   },
 ];
 

--- a/src/app/organizations/users-roles.resolver.ts
+++ b/src/app/organizations/users-roles.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-import { Observable, of, map } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { KubernetesClientService } from '../core/kubernetes-client.service';
 import { RoleBindingList } from '../types/role-bindings';
 
@@ -13,19 +13,8 @@ export class UsersRolesResolver implements Resolve<RoleBindingList | undefined> 
   resolve(route: ActivatedRouteSnapshot): Observable<RoleBindingList | undefined> {
     const name = route.paramMap.get('name');
     if (name) {
-      return this.kubernetesClientService.getRoleBindings(name); //.pipe(map(this.mapToUserRoles));
+      return this.kubernetesClientService.getRoleBindings(name);
     }
     return of(undefined);
-  }
-
-  private mapToUserRoles(roleBindings: RoleBindingList): Record<string, string[]> {
-    const userRoles: Record<string, string[]> = {};
-    roleBindings.items.forEach((item) => {
-      item.subjects.forEach((subj) => {
-        if (!userRoles[subj.name]) userRoles[subj.name] = [];
-        userRoles[subj.name].push(item.roleRef.name);
-      });
-    });
-    return userRoles;
   }
 }

--- a/src/app/organizations/users-roles.resolver.ts
+++ b/src/app/organizations/users-roles.resolver.ts
@@ -7,13 +7,13 @@ import { RoleBindingList } from '../types/role-bindings';
 @Injectable({
   providedIn: 'root',
 })
-export class UsersRolesResolver implements Resolve<Record<string, string[]> | undefined> {
+export class UsersRolesResolver implements Resolve<RoleBindingList | undefined> {
   constructor(private kubernetesClientService: KubernetesClientService) {}
 
-  resolve(route: ActivatedRouteSnapshot): Observable<Record<string, string[]> | undefined> {
+  resolve(route: ActivatedRouteSnapshot): Observable<RoleBindingList | undefined> {
     const name = route.paramMap.get('name');
     if (name) {
-      return this.kubernetesClientService.getRoleBindings(name).pipe(map(this.mapToUserRoles));
+      return this.kubernetesClientService.getRoleBindings(name); //.pipe(map(this.mapToUserRoles));
     }
     return of(undefined);
   }

--- a/src/app/organizations/users-roles.resolver.ts
+++ b/src/app/organizations/users-roles.resolver.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { Observable, of, map } from 'rxjs';
+import { KubernetesClientService } from '../core/kubernetes-client.service';
+import { RoleBindingList } from '../types/role-bindings';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UsersRolesResolver implements Resolve<Record<string, string[]> | undefined> {
+  constructor(private kubernetesClientService: KubernetesClientService) {}
+
+  resolve(route: ActivatedRouteSnapshot): Observable<Record<string, string[]> | undefined> {
+    const name = route.paramMap.get('name');
+    if (name) {
+      return this.kubernetesClientService.getRoleBindings(name).pipe(map(this.mapToUserRoles));
+    }
+    return of(undefined);
+  }
+
+  private mapToUserRoles(roleBindings: RoleBindingList): Record<string, string[]> {
+    const userRoles: Record<string, string[]> = {};
+    roleBindings.items.forEach((item) => {
+      item.subjects.forEach((subj) => {
+        if (!userRoles[subj.name]) userRoles[subj.name] = [];
+        userRoles[subj.name].push(item.roleRef.name);
+      });
+    });
+    return userRoles;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -18,6 +18,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { FocusTrapModule } from 'primeng/focustrap';
 import { MessageModule } from 'primeng/message';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { MultiSelectModule } from 'primeng/multiselect';
 
 @NgModule({
   declarations: [],
@@ -42,6 +43,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
     FocusTrapModule,
     MessageModule,
     ConfirmDialogModule,
+    MultiSelectModule,
   ],
 })
 export class SharedModule {}

--- a/src/app/types/role-bindings.ts
+++ b/src/app/types/role-bindings.ts
@@ -1,6 +1,8 @@
 export interface RoleBindings {
   metadata: {
     namespace: string;
+    name: string;
+    [key: string]: unknown;
   };
   roleRef: { apiGroup: string; kind: 'ClusterRole' | 'Role'; name: string };
   subjects: { apiGroup: string; kind: 'User' | 'Group' | 'ServiceAccount'; name: string }[];

--- a/src/app/types/role-bindings.ts
+++ b/src/app/types/role-bindings.ts
@@ -1,0 +1,16 @@
+export interface RoleBindings {
+  metadata: {
+    namespace: string;
+  };
+  roleRef: { apiGroup: string; kind: 'ClusterRole' | 'Role'; name: string };
+  subjects: { apiGroup: string; kind: 'User' | 'Group' | 'ServiceAccount'; name: string }[];
+}
+
+export interface RoleBindingList {
+  kind: 'RoleBindingsList';
+  apiVersion: 'rbac.authorization.k8s.io/v1';
+  metadata: {
+    resourceVersion: string;
+  };
+  items: RoleBindings[];
+}


### PR DESCRIPTION
## Summary

User can view and edit other users' organization roles (viewer & admin)

Closes https://github.com/appuio/cloud-portal/issues/149

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
