### PR TITLE
🐛 close menu drawer on small screens

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="min-h-screen flex surface-ground">
   <div
-    class="bg-blue-500 h-screen hidden lg:block flex-shrink-0 fixed lg:sticky left-0 top-0 z-1 select-none"
+    class="bg-blue-500 h-screen hidden-on-mobile flex-shrink-0 absolute lg:sticky left-0 top-0 z-1 select-none"
     id="app-sidebar"
     style="width: 280px">
     <div class="flex flex-column h-full">
@@ -9,7 +9,11 @@
       </div>
       <div class="overflow-y-auto mt-3">
         <ul class="list-none p-3 m-0">
-          <li *ngFor="let menuItem of menuItems">
+          <li
+            *ngFor="let menuItem of menuItems"
+            leaveToClass="hidden-on-mobile"
+            leaveActiveClass="fadeoutleft-mobile-only"
+            pStyleClass="#app-sidebar">
             <app-navbar-item [menuItem]="menuItem"></app-navbar-item>
           </li>
         </ul>
@@ -28,9 +32,9 @@
           [hideOnOutsideClick]="true"
           class="cursor-pointer block lg:hidden text-700 mr-3"
           enterActiveClass="fadeinleft"
-          enterClass="hidden"
-          leaveActiveClass="fadeoutleft"
-          leaveToClass="hidden"
+          enterClass="hidden-on-mobile"
+          leaveActiveClass="fadeoutleft-mobile-only"
+          leaveToClass="hidden-on-mobile"
           pRipple
           pStyleClass="#app-sidebar">
           <i class="pi pi-bars text-4xl"></i>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,28 @@
+/** 
+CSS classes so the animation to hide/show the menu drawer looks good on both small and larger screens. 
+Using e.g. hidden & lg:block classes - like we usually do - leads to ugly flickering 
+*/
+.hidden-on-mobile {
+  display: none;
+  @media screen and (min-width: 992px) {
+    display: block;
+  }
+}
+
+.fadeoutleft-mobile-only {
+  @media screen and (max-width: 991px) {
+    animation: fadeoutleft 0.15s linear;
+
+    @keyframes fadeoutleft {
+      0% {
+        opacity: 1;
+        transform: translateX(0%);
+        transition: transform 0.12s cubic-bezier(0, 0, 0.2, 1), opacity 0.12s cubic-bezier(0, 0, 0.2, 1);
+      }
+      100% {
+        opacity: 0;
+        transform: translateX(-100%);
+      }
+    }
+  }
+}

--- a/src/app/identity-menu/identity-menu.component.html
+++ b/src/app/identity-menu/identity-menu.component.html
@@ -1,4 +1,4 @@
-<div class="flex align-items-center flex-column relative z-1 bg-white text-color">
+<div class="flex align-items-center flex-column relative bg-white text-color">
   <a
     class="px-3 py-2 flex align-items-center align-self-end hover:bg-primary cursor-pointer hover:text-blue-50 transition-duration-150 transition-colors"
     style="height: 59px"

--- a/src/app/info-menu/info-menu.component.html
+++ b/src/app/info-menu/info-menu.component.html
@@ -1,4 +1,4 @@
-<div class="flex align-items-center flex-column z-1 relative bg-white text-color">
+<div class="flex align-items-center flex-column relative bg-white text-color">
   <a
     class="px-3 py-2 flex align-items-center align-self-end hover:bg-primary cursor-pointer hover:text-blue-50 transition-duration-150 transition-colors"
     style="height: 59px"


### PR DESCRIPTION
## Summary

On small screens, the menu drawer now closes properly when clicking on a menu item or outside of it

Closes https://github.com/appuio/cloud-portal/issues/182


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
