### PR TITLE
Show error message if user details fail to load

### DIFF
--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   ENVIRONMENT: preview
-  OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
+  OPENSHIFT_API: https://api.cloudscale-lpg-2.appuio.cloud:6443
   HELM_RELEASE_NAME: portal-pr-${{ github.event.number }}
   IMG_TAG: pr-${{ github.event.number }}
   NAMESPACE: appuio-control-api-preview

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -29,7 +29,7 @@ on:
         required: true
 
 env:
-  OPENSHIFT_API: https://api.c-appuio-cloudscale-lpg-2.appuio.cloud:6443
+  OPENSHIFT_API: https://api.cloudscale-lpg-2.appuio.cloud:6443
 
 jobs:
   install:

--- a/src/app/store/app.effects.ts
+++ b/src/app/store/app.effects.ts
@@ -26,6 +26,7 @@ import { routerNavigatedAction } from '@ngrx/router-store';
 import { selectUser } from './app.selectors';
 import { EntityState } from '../types/entity';
 import { User } from '../types/user';
+import { loadTeamsFailure } from '../teams/store/team.actions';
 
 @Injectable()
 export class AppEffects {
@@ -44,7 +45,7 @@ export class AppEffects {
   loadZonesFailure$ = createEffect(
     () => {
       return this.actions$.pipe(
-        ofType(loadZonesFailure),
+        ofType(loadZonesFailure, loadOrganizationsFailure, loadUserFailure, loadTeamsFailure),
         tap(({ errorMessage }) => {
           this.messageService.add({
             severity: 'error',

--- a/src/app/user/user-settings/user-settings.component.html
+++ b/src/app/user/user-settings/user-settings.component.html
@@ -26,7 +26,7 @@
     <p-messages severity="error">
       <ng-template pTemplate="content">
         <fa-icon [icon]="faWarning"></fa-icon>
-        <div class="ml-2" i18n id="organization-failure-message">User details failed to load.</div>
+        <div class="ml-2" i18n id="user-failure-message">User details failed to load.</div>
       </ng-template>
     </p-messages>
   </ng-container>

--- a/src/app/user/user-settings/user-settings.component.html
+++ b/src/app/user/user-settings/user-settings.component.html
@@ -1,7 +1,7 @@
 <h1 class="pt-0 mt-0" i18n id="zones-title">User Settings</h1>
 
-<ng-container *ngIf="user$ | ngrxPush as user">
-  <ng-container *ngIf="user.state === EntityState.Loaded; else loading">
+<ng-container *ngIf="user$ | ngrxPush as user" [ngSwitch]="user.state">
+  <ng-container *ngSwitchCase="EntityState.Loaded">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">
@@ -13,12 +13,21 @@
       </div>
     </div>
   </ng-container>
-</ng-container>
 
-<ng-template #loading>
-  <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
-    <div class="flex flex-row justify-content-between">
-      <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+  <ng-container *ngSwitchCase="EntityState.Loading">
+    <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
+      <div class="flex flex-row justify-content-between">
+        <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+      </div>
     </div>
-  </div>
-</ng-template>
+  </ng-container>
+
+  <ng-container *ngSwitchCase="EntityState.Failed">
+    <p-messages severity="error">
+      <ng-template pTemplate="content">
+        <fa-icon [icon]="faWarning"></fa-icon>
+        <div class="ml-2" i18n id="organization-failure-message">User details failed to load.</div>
+      </ng-template>
+    </p-messages>
+  </ng-container>
+</ng-container>

--- a/src/app/user/user-settings/user-settings.component.ts
+++ b/src/app/user/user-settings/user-settings.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { selectUser } from '../../store/app.selectors';
 import { Store } from '@ngrx/store';
 import { EntityState } from '../../types/entity';
+import { faWarning } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-user-settings',
@@ -15,4 +16,6 @@ export class UserSettingsComponent {
   constructor(private store: Store) {}
 
   user$ = this.store.select(selectUser);
+
+  faWarning = faWarning;
 }


### PR DESCRIPTION
## Summary

If fetching the user details failed (e.g. due to server / network error), the user settings page continued to display a loading spinner. Now it correctly shows an error message. 

Also shows an error message toast if fetching any of the main data (zones, user, teams, orgs) fails. 

Fixes https://github.com/appuio/cloud-portal/issues/226

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
