### PR TITLE
Unifies menu structure across all documentation sites

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,6 @@
 * xref:index.adoc[Home]
+* xref:user:ROOT:index.adoc[APPUiO Cloud User Documentation 🔗^]
+* xref:appcat:ROOT:index.adoc[VSHN AppCat Documentation 🔗^]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,8 +1,8 @@
 * xref:user:ROOT:contact.adoc[Contact]
 * https://status.appuio.cloud[Status 🔗^]
 * https://portal.appuio.cloud[Portal 🔗^]
-* xref:user:ROOT:index.adoc[User Docs 🔗^]
-* xref:appcat:ROOT:index.adoc[AppCat Docs 🔗^]
+* xref:user:ROOT:index.adoc[User Docs]
+* xref:appcat:ROOT:index.adoc[AppCat Docs]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,8 +1,9 @@
+* xref:user:ROOT:index.adoc[User Docs]
+* xref:portal:ROOT:index.adoc[Portal Docs]
+* xref:appcat:ROOT:index.adoc[AppCat Docs]
 * xref:user:ROOT:contact.adoc[Contact]
 * https://status.appuio.cloud[Status 🔗^]
 * https://portal.appuio.cloud[Portal 🔗^]
-* xref:user:ROOT:index.adoc[User Docs]
-* xref:appcat:ROOT:index.adoc[AppCat Docs]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,6 @@
 * xref:index.adoc[Home]
-* xref:user:ROOT:index.adoc[APPUiO Cloud User Documentation 🔗^]
-* xref:appcat:ROOT:index.adoc[VSHN AppCat Documentation 🔗^]
+* xref:user:ROOT:index.adoc[APPUiO Cloud User Docs 🔗^]
+* xref:appcat:ROOT:index.adoc[VSHN AppCat Docs 🔗^]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,5 @@
 include::user:ROOT:partial$shared-nav.adoc[]
 
-.How-to guides
-** xref:how-to/find-username.adoc[Find your Username]
-** xref:how-to/organizations.adoc[Managing Organizations]
-** xref:how-to/teams.adoc[Managing Teams]
+* xref:how-to/find-username.adoc[Find your Username]
+* xref:how-to/organizations.adoc[Managing Organizations]
+* xref:how-to/teams.adoc[Managing Teams]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 include::user:ROOT:partial$shared-nav.adoc[]
 
-* xref:how-to/find-username.adoc[Find your Username]
-* xref:how-to/organizations.adoc[Managing Organizations]
-* xref:how-to/teams.adoc[Managing Teams]
+.Common Tasks
+** xref:how-to/find-username.adoc[Find your Username]
+** xref:how-to/organizations.adoc[Managing Organizations]
+** xref:how-to/teams.adoc[Managing Teams]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,9 +1,4 @@
-* xref:user:ROOT:index.adoc[User Docs]
-* xref:portal:ROOT:index.adoc[Portal Docs]
-* xref:appcat:ROOT:index.adoc[AppCat Docs]
-* xref:user:ROOT:contact.adoc[Contact]
-* https://status.appuio.cloud[Status 🔗^]
-* https://portal.appuio.cloud[Portal 🔗^]
+include::user:ROOT:partial$shared-nav.adoc[]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,8 @@
-* xref:index.adoc[Home]
-* xref:user:ROOT:index.adoc[APPUiO Cloud User Docs 🔗^]
-* xref:appcat:ROOT:index.adoc[VSHN AppCat Docs 🔗^]
+* xref:user:ROOT:contact.adoc[Contact]
+* https://status.appuio.cloud[Status 🔗^]
+* https://portal.appuio.cloud[Portal 🔗^]
+* xref:user:ROOT:index.adoc[User Docs 🔗^]
+* xref:appcat:ROOT:index.adoc[AppCat Docs 🔗^]
 
 .How-to guides
 ** xref:how-to/find-username.adoc[Find your Username]


### PR DESCRIPTION
## Summary

Unifies menu structure across all APPUiO Cloud Antora documentation websites using a shared `include` stored in the main documentation (APPUiO Cloud for Users).

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.
