### PR TITLE
👷 replace deprecated set-output command

### DIFF
--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Gather deployment status
         id: deployment_info
         run: |
-          echo ::set-output name=route_host::"$(oc -n ${{ env.NAMESPACE }} get route ${{ env.HELM_RELEASE_NAME }} -o jsonpath='{.spec.host}')"
+          echo route_host="$(oc -n ${{ env.NAMESPACE }} get route ${{ env.HELM_RELEASE_NAME }} -o jsonpath='{.spec.host}')" >> $GITHUB_OUTPUT
 
       - name: Uninstall app
         run: helmfile --namespace ${{ env.NAMESPACE }} --file deployment/helmfile.yaml -e ${{ env.ENVIRONMENT }} destroy --args --wait

--- a/.github/workflows/template-deploy.yaml
+++ b/.github/workflows/template-deploy.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Gather deployment status
         id: deployment_info
         run: |
-          echo ::set-output name=route_host::"$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')"
+          echo route_host="$(oc -n ${{ inputs.namespace }} get route ${{ inputs.helm_release_name }} -o jsonpath='{.spec.host}')" >> $GITHUB_OUTPUT
 
       - name: Add route URL to Keycloak client
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

The `set-output` action is deprecated and causes a warning in each build, which prevents Renovate PRsfrom merging automatically. 
Therefore, replacing it with `>> $GITHUB_OUTPUT ` in all workflow definitions as described in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
