### PR TITLE
List Billing entities

### DIFF
--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -1,0 +1,72 @@
+import { createUser } from '../fixtures/user';
+import { billingEntityNxt, billingEntityVshn } from '../fixtures/billingentities';
+
+describe('Test billing entity list', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // needed for initial getUser request
+    cy.setPermission({ verb: 'list', resource: 'zones', group: 'rbac.appuio.io' });
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig', defaultOrganizationRef: 'nxt' }),
+    });
+  });
+
+  it('list with two entries', () => {
+    cy.setPermission({ verb: 'list', resource: 'billingentities', group: 'billing.appuio.io' });
+    cy.intercept('GET', 'appuio-api/apis/billing.appuio.io/v1/billingentities', {
+      body: { items: [billingEntityNxt, billingEntityVshn] },
+    });
+    cy.visit('/billingentities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
+  });
+
+  it('empty list', () => {
+    cy.setPermission({ verb: 'list', resource: 'billingentities', group: 'billing.appuio.io' });
+    cy.intercept('GET', 'appuio-api/apis/billing.appuio.io/v1/billingentities', {
+      body: { items: [] },
+    });
+    cy.visit('/billingentities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#no-billingentity-message').should('contain.text', 'No billing entities available.');
+  });
+
+  it('request failed', () => {
+    cy.setPermission({ verb: 'list', resource: 'billingentities', group: 'billing.appuio.io' });
+    cy.intercept('GET', 'appuio-api/apis/billing.appuio.io/v1/billingentities', {
+      statusCode: 403,
+    });
+    cy.visit('/billingentities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#billingentity-failure-message').should('contain.text', 'Billing entities could not be loaded.');
+  });
+
+  it('failed requests are retried', () => {
+    cy.setPermission({ verb: 'list', resource: 'billingentities', group: 'billing.appuio.io' });
+
+    let interceptCount = 0;
+    cy.intercept('GET', 'appuio-api/apis/billing.appuio.io/v1/billingentities', (req) => {
+      if (interceptCount === 0) {
+        interceptCount++;
+        req.reply({ statusCode: 503 });
+      } else {
+        req.reply({ items: [billingEntityNxt, billingEntityVshn] });
+      }
+    });
+    cy.visit('/billingentities');
+
+    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
+  });
+
+  it('no permission', () => {
+    cy.visit('/billingentities');
+    cy.get('h1').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+  });
+});

--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -21,7 +21,7 @@ describe('Test billing entity list', () => {
       body: { items: [billingEntityNxt, billingEntityVshn] },
     });
     cy.visit('/billingentities');
-    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing');
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
   });
@@ -32,7 +32,7 @@ describe('Test billing entity list', () => {
       body: { items: [] },
     });
     cy.visit('/billingentities');
-    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing');
     cy.get('#no-billingentity-message').should('contain.text', 'No billing entities available.');
   });
 
@@ -42,7 +42,7 @@ describe('Test billing entity list', () => {
       statusCode: 403,
     });
     cy.visit('/billingentities');
-    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing');
     cy.get('#billingentity-failure-message').should('contain.text', 'Billing entities could not be loaded.');
   });
 
@@ -60,7 +60,7 @@ describe('Test billing entity list', () => {
     });
     cy.visit('/billingentities');
 
-    cy.get('#billingentities-title').should('contain.text', 'Billing Entities');
+    cy.get('#billingentities-title').should('contain.text', 'Billing');
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
   });

--- a/cypress/fixtures/billingentities.ts
+++ b/cypress/fixtures/billingentities.ts
@@ -1,0 +1,51 @@
+import { BillingEntity } from '../../src/app/types/billing-entity';
+
+export const billingEntityNxt: BillingEntity = {
+  kind: 'BillingEntity',
+  apiVersion: 'billing.appuio.io/v1',
+  metadata: {
+    name: 'be-2345',
+  },
+  spec: {
+    name: 'NXT Engineering',
+    address: {
+      line1: '📃',
+      line2: '📋',
+      postalCode: '🏤',
+      city: '🏙️',
+      country: '🇨🇭',
+    },
+    emails: ['📧'],
+    phone: '☎️',
+    languagePreference: '🇩🇪',
+    accountingContact: {
+      name: 'mig',
+      emails: ['📧'],
+    },
+  },
+};
+
+export const billingEntityVshn: BillingEntity = {
+  kind: 'BillingEntity',
+  apiVersion: 'billing.appuio.io/v1',
+  metadata: {
+    name: 'be-2347',
+  },
+  spec: {
+    name: 'VSHN AG',
+    address: {
+      line1: '📃',
+      line2: '📋',
+      postalCode: '🏤',
+      city: '🏙️',
+      country: '🇨🇭',
+    },
+    emails: ['📧'],
+    phone: '☎️',
+    languagePreference: '🇬🇧',
+    accountingContact: {
+      name: 'mig',
+      emails: ['📧'],
+    },
+  },
+};

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -44,7 +44,7 @@ const routes: Routes = [
   {
     path: 'billingentities',
     loadChildren: () => import('./billingentity/billing-entity.module'),
-    title: $localize`Billing Entities`,
+    title: $localize`Billing`,
   },
   {
     path: 'user',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -42,6 +42,11 @@ const routes: Routes = [
     title: $localize`Teams`,
   },
   {
+    path: 'billingentities',
+    loadChildren: () => import('./billingentity/billing-entity.module'),
+    title: $localize`Billing Entities`,
+  },
+  {
     path: 'user',
     loadChildren: () => import('./user/user.module'),
     title: $localize`User Settings`,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -127,5 +127,4 @@ const clusterStartupAccessChecks = [
   composeSsarId(new SelfSubjectAccessReview(Verb.List, 'organizations', 'rbac.appuio.io', '')),
   composeSsarId(new SelfSubjectAccessReview(Verb.Create, 'organizations', 'rbac.appuio.io', '')),
   composeSsarId(new SelfSubjectAccessReview(Verb.Update, 'organizations', 'rbac.appuio.io', '')),
-  composeSsarId(new SelfSubjectAccessReview(Verb.List, 'billingentities', 'billing.appuio.io', '')),
 ];

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -107,7 +107,7 @@ export class AppComponent implements OnInit {
       .pipe(filter((allowed) => allowed))
       .subscribe(() => {
         this.menuItems.push({
-          label: $localize`Billing Entities`,
+          label: $localize`Billing`,
           icon: faDollarSign,
           routerLink: ['billingentities'],
         });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { OAuthService } from 'angular-oauth2-oidc';
 import { Store } from '@ngrx/store';
 import { selectOrganizationSelectionEnabled, selectPermission } from './store/app.selectors';
 import { Permission, Verb } from './store/app.reducer';
-import { faComment, faDatabase, faSitemap, faUserGroup } from '@fortawesome/free-solid-svg-icons';
+import { faComment, faDatabase, faDollarSign, faSitemap, faUserGroup } from '@fortawesome/free-solid-svg-icons';
 import { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import * as Sentry from '@sentry/browser';
 import { AppConfigService } from './app-config.service';
@@ -100,6 +100,11 @@ export class AppComponent implements OnInit {
       label: $localize`Teams`,
       icon: faUserGroup,
       routerLink: ['teams'],
+    });
+    this.menuItems.push({
+      label: $localize`Billing Entities`,
+      icon: faDollarSign,
+      routerLink: ['billingentities'],
     });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -104,12 +104,7 @@ export class AppComponent implements OnInit {
     });
     this.ssarCollectionService
       .isAllowed('billing.appuio.io', 'billingentities', Verb.List, '')
-      .pipe(
-        // The underlying SSAR collection may change as they get loaded at app start, so we limit to only 1 if allowed,
-        // otherwise there could be multiple menuitems for the same.
-        filter((allowed) => allowed),
-        take(1)
-      )
+      .pipe(filter((allowed) => allowed))
       .subscribe(() => {
         this.menuItems.push({
           label: $localize`Billing Entities`,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { environment } from '../environments/environment';
 import { AuthConfig, OAuthModule, OAuthService } from 'angular-oauth2-oidc';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClient, HttpClientModule } from '@angular/common/http';
 import { NavbarItemComponent } from './navbar-item/navbar-item.component';
 import { AppConfigService } from './app-config.service';
 import { forkJoin, mergeMap, Observable, retry } from 'rxjs';
@@ -34,6 +34,7 @@ import { TitleStrategy } from '@angular/router';
 import { AppAndPageTitleStrategy } from './title-strategy';
 import { EntityDataModule, EntityDataService, EntityDefinitionService } from '@ngrx/data';
 import {
+  billingEntityEntityKey,
   entityConfig,
   entityMetadataMap,
   organizationEntityKey,
@@ -42,6 +43,9 @@ import {
 import { SelfSubjectAccessReviewDataService } from './store/ssar-data.service';
 import { OrganizationCollectionService } from './organizations/organization-collection.service';
 import { OrganizationDataService } from './organizations/organization-data.service';
+import { KubernetesDataService } from './store/kubernetes-data.service';
+import { KubernetesUrlGenerator } from './store/kubernetes-url-generator.service';
+import { BillingEntity } from './types/billing-entity';
 
 @NgModule({
   declarations: [
@@ -95,10 +99,19 @@ import { OrganizationDataService } from './organizations/organization-data.servi
   bootstrap: [AppComponent],
 })
 export class AppModule {
-  constructor(entityDefinitionService: EntityDefinitionService, entityDataService: EntityDataService) {
+  constructor(
+    entityDefinitionService: EntityDefinitionService,
+    entityDataService: EntityDataService,
+    http: HttpClient,
+    urlGenerator: KubernetesUrlGenerator
+  ) {
     entityDefinitionService.registerMetadataMap(entityMetadataMap);
     entityDataService.registerService(selfSubjectAccessReviewEntityKey, inject(SelfSubjectAccessReviewDataService));
     entityDataService.registerService(organizationEntityKey, inject(OrganizationDataService));
+    entityDataService.registerService(
+      billingEntityEntityKey,
+      new KubernetesDataService<BillingEntity>(billingEntityEntityKey, http, urlGenerator)
+    );
   }
 }
 

--- a/src/app/billingentity/billing-entity-resolver.service.ts
+++ b/src/app/billingentity/billing-entity-resolver.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { BillingEntity } from '../types/billing-entity';
+import { EntityCollectionService, EntityCollectionServiceFactory } from '@ngrx/data';
+import { billingEntityEntityKey } from '../store/entity-metadata-map';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BillingEntityResolver implements Resolve<BillingEntity | undefined> {
+  private billingService: EntityCollectionService<BillingEntity>;
+
+  constructor(private entityFactory: EntityCollectionServiceFactory) {
+    this.billingService = entityFactory.create<BillingEntity>(billingEntityEntityKey);
+  }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<BillingEntity | undefined> {
+    const name = route.paramMap.get('name');
+    if (!name) {
+      return of(undefined);
+    }
+    return this.billingService.getByKey(name);
+  }
+}

--- a/src/app/billingentity/billing-entity-routing.module.ts
+++ b/src/app/billingentity/billing-entity-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { BillingEntityComponent } from './billing-entity.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: BillingEntityComponent,
+    //canActivate: [PermissionGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class BillingEntityRoutingModule {}

--- a/src/app/billingentity/billing-entity-routing.module.ts
+++ b/src/app/billingentity/billing-entity-routing.module.ts
@@ -3,12 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { BillingEntityComponent } from './billing-entity.component';
 import { BillingentityViewComponent } from './billingentity-view/billingentity-view.component';
 import { BillingEntityResolver } from './billingentity-view/billing-entity-resolver.service';
+import { BillingEntityGuard } from './billing-entity.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: BillingEntityComponent,
-    //canActivate: [PermissionGuard],
+    canActivate: [BillingEntityGuard],
   },
   {
     path: ':name',
@@ -16,6 +17,7 @@ const routes: Routes = [
     resolve: {
       billingEntity: BillingEntityResolver,
     },
+    canActivate: [BillingEntityGuard],
   },
 ];
 

--- a/src/app/billingentity/billing-entity-routing.module.ts
+++ b/src/app/billingentity/billing-entity-routing.module.ts
@@ -1,12 +1,21 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { BillingEntityComponent } from './billing-entity.component';
+import { BillingentityViewComponent } from './billingentity-view/billingentity-view.component';
+import { BillingEntityResolver } from './billingentity-view/billing-entity-resolver.service';
 
 const routes: Routes = [
   {
     path: '',
     component: BillingEntityComponent,
     //canActivate: [PermissionGuard],
+  },
+  {
+    path: ':name',
+    component: BillingentityViewComponent,
+    resolve: {
+      billingEntity: BillingEntityResolver,
+    },
   },
 ];
 

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -1,1 +1,101 @@
-<p *ngFor="let b of billingEntityService.entities$ | ngrxPush">{{ b.metadata.name }}</p>
+<div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
+  <h1 class="pt-0 mt-0 mb-0" i18n id="organizations-title">Billing Entities</h1>
+</div>
+
+<ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
+  <ng-container *ngFor="let billingEntity of billingEntityService.entities$ | ngrxPush; index as i">
+    <div class="surface-card p-4 shadow-2 border-round mb-4">
+      <div class="flex flex-row justify-content-between">
+        <div class="text-3xl font-medium text-900 mb-3">
+          {{ billingEntity.metadata.name }}
+        </div>
+      </div>
+      <div class="flex flex-wrap border-top-1 surface-border">
+        <ul class="w-full list-none p-0 m-0 surface-border">
+          <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
+            <div class="text-900 w-full md:w-9">
+              {{ billingEntity.spec.name }}
+            </div>
+          </li>
+          <li *ngIf="billingEntity.spec.emails" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Company Email</div>
+            <div class="text-900 w-full md:w-9">
+              <ul *ngFor="let email of billingEntity.spec.emails" class="pl-0 list-none">
+                <li>{{ email }}</li>
+              </ul>
+            </div>
+          </li>
+          <li *ngIf="billingEntity.spec.phone" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Phone</div>
+            <div class="text-900 w-full md:w-9">
+              {{ billingEntity.spec.phone }}
+            </div>
+          </li>
+          <li *ngIf="billingEntity.spec.address" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Address</div>
+            <div class="text-900 w-full md:w-9">
+              <div>{{ billingEntity.spec.address.line1 }}</div>
+              <div>{{ billingEntity.spec.address.line2 }}</div>
+              <div>{{ billingEntity.spec.address.postalCode }} {{ billingEntity.spec.address.city }}</div>
+              <div>{{ billingEntity.spec.address.country }}</div>
+            </div>
+          </li>
+          <li *ngIf="billingEntity.spec.accountingContact"
+              class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Invoice Recipient</div>
+            <div class="text-900 w-full md:w-9">
+              {{ billingEntity.spec.accountingContact.name }}
+              <ul *ngFor="let email of billingEntity.spec.accountingContact.emails" class="pl-0 list-none">
+                <li>{{ email }}</li>
+              </ul>
+            </div>
+          </li>
+          <li *ngIf="billingEntity.spec.languagePreference"
+              class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <div class="text-500 w-full md:w-3 font-medium" i18n>Language Preference</div>
+            <div class="text-900 w-full md:w-9">
+              {{ billingEntity.spec.languagePreference }}
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </ng-container>
+</ng-container>
+
+
+<ng-container *ngIf="billingEntityService.loading$ | ngrxPush">
+  <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
+    <div class="flex flex-row justify-content-between">
+      <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+    </div>
+
+    <div class="flex flex-wrap border-top-1 surface-border">
+      <ul class="w-full list-none p-0 m-0 surface-border">
+        <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
+          <div class="text-900 w-full md:w-9">&#8230;</div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</ng-container>
+
+<ng-container *ngIf="(billingEntityService.loaded$ | ngrxPush) && (billingEntityService.count$ | ngrxPush) === 0">
+  <p-messages severity="info">
+    <ng-template pTemplate="content">
+      <fa-icon [icon]="faInfo"></fa-icon>
+      <div class="ml-2" i18n id="no-organization-message">No billing entities available.</div>
+    </ng-template>
+  </p-messages>
+</ng-container>
+
+<ng-container *ngIf="loadErrors() | ngrxPush">
+  <p-messages severity="error">
+    <ng-template pTemplate="content">
+      <fa-icon [icon]="faWarning"></fa-icon>
+      <div class="ml-2" i18n id="organization-failure-message">Billing entities could not be loaded.</div>
+    </ng-template>
+  </p-messages>
+</ng-container>

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
-  <ng-container *ngFor="let billingEntity of billingEntityService.entities$ | ngrxPush">
+  <ng-container *ngFor="let billingEntity of billingEntityService.getAllMemoized() | ngrxPush">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
-  <ng-container *ngFor="let billingEntity of billingEntityService.entities$ | ngrxPush; index as i">
+  <ng-container *ngFor="let billingEntity of billingEntityService.entities$ | ngrxPush">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">
@@ -18,44 +18,11 @@
               {{ billingEntity.spec.name }}
             </div>
           </li>
-          <li *ngIf="billingEntity.spec.emails" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
-            <div class="text-500 w-full md:w-3 font-medium" i18n>Company Email</div>
-            <div class="text-900 w-full md:w-9">
-              <ul *ngFor="let email of billingEntity.spec.emails" class="pl-0 list-none">
-                <li>{{ email }}</li>
-              </ul>
-            </div>
-          </li>
-          <li *ngIf="billingEntity.spec.phone" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
-            <div class="text-500 w-full md:w-3 font-medium" i18n>Phone</div>
-            <div class="text-900 w-full md:w-9">
-              {{ billingEntity.spec.phone }}
-            </div>
-          </li>
-          <li *ngIf="billingEntity.spec.address" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
-            <div class="text-500 w-full md:w-3 font-medium" i18n>Address</div>
-            <div class="text-900 w-full md:w-9">
-              <div>{{ billingEntity.spec.address.line1 }}</div>
-              <div>{{ billingEntity.spec.address.line2 }}</div>
-              <div>{{ billingEntity.spec.address.postalCode }} {{ billingEntity.spec.address.city }}</div>
-              <div>{{ billingEntity.spec.address.country }}</div>
-            </div>
-          </li>
           <li *ngIf="billingEntity.spec.accountingContact"
               class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
             <div class="text-500 w-full md:w-3 font-medium" i18n>Invoice Recipient</div>
             <div class="text-900 w-full md:w-9">
               {{ billingEntity.spec.accountingContact.name }}
-              <ul *ngFor="let email of billingEntity.spec.accountingContact.emails" class="pl-0 list-none">
-                <li>{{ email }}</li>
-              </ul>
-            </div>
-          </li>
-          <li *ngIf="billingEntity.spec.languagePreference"
-              class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
-            <div class="text-500 w-full md:w-3 font-medium" i18n>Language Preference</div>
-            <div class="text-900 w-full md:w-9">
-              {{ billingEntity.spec.languagePreference }}
             </div>
           </li>
         </ul>

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
-  <h1 class="pt-0 mt-0 mb-0" i18n id="billingentities-title">Billing Entities</h1>
+  <h1 class="pt-0 mt-0 mb-0" i18n id="billingentities-title">Billing</h1>
 </div>
 
 <ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
@@ -14,7 +14,7 @@
             [routerLink]="[billingEntity.metadata.name]"
             class="text-blue-500 hover:text-primary cursor-pointer mr-2"
             i18n-title
-            title="Edit members">
+            title="Edit details">
             <fa-icon [icon]="faEdit"></fa-icon>
           </a>
         </div>

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -1,0 +1,1 @@
+<p *ngFor="let b of billingEntityService.entities$ | ngrxPush">{{ b.metadata.name }}</p>

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
-  <ng-container *ngFor="let billingEntity of billingEntityService.getAllMemoized() | ngrxPush">
+  <ng-container *ngFor="let billingEntity of billingEntities$| ngrxPush">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
-  <h1 class="pt-0 mt-0 mb-0" i18n id="organizations-title">Billing Entities</h1>
+  <h1 class="pt-0 mt-0 mb-0" i18n id="billingentities-title">Billing Entities</h1>
 </div>
 
 <ng-container *ngIf="(billingEntityService.loading$ | ngrxPush) === false">
@@ -8,6 +8,15 @@
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">
           {{ billingEntity.metadata.name }}
+        </div>
+        <div>
+          <a
+            [routerLink]="[billingEntity.metadata.name]"
+            class="text-blue-500 hover:text-primary cursor-pointer mr-2"
+            i18n-title
+            title="Edit members">
+            <fa-icon [icon]="faEdit"></fa-icon>
+          </a>
         </div>
       </div>
       <div class="flex flex-wrap border-top-1 surface-border">
@@ -53,7 +62,7 @@
   <p-messages severity="info">
     <ng-template pTemplate="content">
       <fa-icon [icon]="faInfo"></fa-icon>
-      <div class="ml-2" i18n id="no-organization-message">No billing entities available.</div>
+      <div class="ml-2" i18n id="no-billingentity-message">No billing entities available.</div>
     </ng-template>
   </p-messages>
 </ng-container>
@@ -62,7 +71,7 @@
   <p-messages severity="error">
     <ng-template pTemplate="content">
       <fa-icon [icon]="faWarning"></fa-icon>
-      <div class="ml-2" i18n id="organization-failure-message">Billing entities could not be loaded.</div>
+      <div class="ml-2" i18n id="billingentity-failure-message">Billing entities could not be loaded.</div>
     </ng-template>
   </p-messages>
 </ng-container>

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -1,10 +1,14 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { EntityCollectionService, EntityCollectionServiceFactory, EntityOp } from '@ngrx/data';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { EntityOp } from '@ngrx/data';
 import { BillingEntity } from '../types/billing-entity';
 import { billingEntityEntityKey } from '../store/entity-metadata-map';
 
 import { faEdit, faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { filter, map, Observable } from 'rxjs';
+import {
+  KubernetesCollectionService,
+  KubernetesCollectionServiceFactory,
+} from '../store/kubernetes-collection.service';
 
 @Component({
   selector: 'app-billing-entity',
@@ -12,19 +16,15 @@ import { filter, map, Observable } from 'rxjs';
   styleUrls: ['./billing-entity.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class BillingEntityComponent implements OnInit {
-  billingEntityService: EntityCollectionService<BillingEntity>;
+export class BillingEntityComponent {
+  billingEntityService: KubernetesCollectionService<BillingEntity>;
 
   faWarning = faWarning;
   faInfo = faInfo;
   faEdit = faEdit;
 
-  constructor(private factory: EntityCollectionServiceFactory) {
+  constructor(private factory: KubernetesCollectionServiceFactory) {
     this.billingEntityService = factory.create<BillingEntity>(billingEntityEntityKey);
-  }
-
-  ngOnInit(): void {
-    this.billingEntityService.getAll().subscribe(); // initial load to cache
   }
 
   loadErrors(): Observable<Error> {

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -16,6 +16,6 @@ export class BillingEntityComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.billingEntityService.getAll().subscribe();
+    this.billingEntityService.getByKey('be-2345').subscribe();
   }
 }

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -3,7 +3,7 @@ import { EntityCollectionService, EntityCollectionServiceFactory, EntityOp } fro
 import { BillingEntity } from '../types/billing-entity';
 import { billingEntityEntityKey } from '../store/entity-metadata-map';
 
-import { faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { filter, map, Observable } from 'rxjs';
 
 @Component({
@@ -17,6 +17,7 @@ export class BillingEntityComponent implements OnInit {
 
   faWarning = faWarning;
   faInfo = faInfo;
+  faEdit = faEdit;
 
   constructor(private factory: EntityCollectionServiceFactory) {
     this.billingEntityService = factory.create<BillingEntity>(billingEntityEntityKey);

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -22,9 +22,11 @@ export class BillingEntityComponent {
   faWarning = faWarning;
   faInfo = faInfo;
   faEdit = faEdit;
+  billingEntities$: Observable<BillingEntity[]>;
 
-  constructor(private factory: KubernetesCollectionServiceFactory) {
-    this.billingEntityService = factory.create<BillingEntity>(billingEntityEntityKey);
+  constructor(private factory: KubernetesCollectionServiceFactory<BillingEntity>) {
+    this.billingEntityService = factory.create(billingEntityEntityKey);
+    this.billingEntities$ = this.billingEntityService.getAllMemoized();
   }
 
   loadErrors(): Observable<Error> {

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -1,7 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { EntityCollectionService, EntityCollectionServiceFactory } from '@ngrx/data';
+import { EntityCollectionService, EntityCollectionServiceFactory, EntityOp } from '@ngrx/data';
 import { BillingEntity } from '../types/billing-entity';
 import { billingEntityEntityKey } from '../store/entity-metadata-map';
+
+import { faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
+import { filter, map, Observable } from 'rxjs';
 
 @Component({
   selector: 'app-billing-entity',
@@ -11,11 +14,26 @@ import { billingEntityEntityKey } from '../store/entity-metadata-map';
 })
 export class BillingEntityComponent implements OnInit {
   billingEntityService: EntityCollectionService<BillingEntity>;
+
+  faWarning = faWarning;
+  faInfo = faInfo;
+
   constructor(private factory: EntityCollectionServiceFactory) {
     this.billingEntityService = factory.create<BillingEntity>(billingEntityEntityKey);
   }
 
   ngOnInit(): void {
-    this.billingEntityService.getByKey('be-2345').subscribe();
+    this.billingEntityService.getAll().subscribe(); // initial load to cache
+  }
+
+  loadErrors(): Observable<Error> {
+    return this.billingEntityService.errors$.pipe(
+      filter((action) => {
+        return action.payload.entityOp == EntityOp.QUERY_ALL_ERROR;
+      }),
+      map((action) => {
+        return action.payload.data.error.error satisfies Error;
+      })
+    );
   }
 }

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { EntityCollectionService, EntityCollectionServiceFactory } from '@ngrx/data';
+import { BillingEntity } from '../types/billing-entity';
+import { billingEntityEntityKey } from '../store/entity-metadata-map';
+
+@Component({
+  selector: 'app-billing-entity',
+  templateUrl: './billing-entity.component.html',
+  styleUrls: ['./billing-entity.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BillingEntityComponent implements OnInit {
+  billingEntityService: EntityCollectionService<BillingEntity>;
+  constructor(private factory: EntityCollectionServiceFactory) {
+    this.billingEntityService = factory.create<BillingEntity>(billingEntityEntityKey);
+  }
+
+  ngOnInit(): void {
+    this.billingEntityService.getAll().subscribe();
+  }
+}

--- a/src/app/billingentity/billing-entity.guard.ts
+++ b/src/app/billingentity/billing-entity.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 import { SelfSubjectAccessReviewCollectionService } from '../store/ssar-collection.service';
 import { Verb } from '../store/app.reducer';
 import { map, Observable, tap } from 'rxjs';
@@ -9,7 +9,7 @@ import { SelfSubjectAccessReview } from '../types/self-subject-access-review';
   providedIn: 'root',
 })
 export class BillingEntityGuard implements CanActivate {
-  constructor(private ssarService: SelfSubjectAccessReviewCollectionService) {}
+  constructor(private ssarService: SelfSubjectAccessReviewCollectionService, private router: Router) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
@@ -19,10 +19,11 @@ export class BillingEntityGuard implements CanActivate {
       )
       .pipe(
         map((ssar) => ssar.status.allowed),
-        tap((allowed) => console.log('allowed', allowed))
+        tap((allowed) => {
+          if (!allowed) {
+            void this.router.navigate(['/home']);
+          }
+        })
       );
-    // return this.ssarService
-    //   .isAllowed('billing.appuio.io', 'billingentities', Verb.List, '')
-    //   .pipe(tap((allowed) => console.log('allowed', allowed)));
   }
 }

--- a/src/app/billingentity/billing-entity.guard.ts
+++ b/src/app/billingentity/billing-entity.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { SelfSubjectAccessReviewCollectionService } from '../store/ssar-collection.service';
+import { Verb } from '../store/app.reducer';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BillingEntityGuard implements CanActivate {
+  constructor(private ssarService: SelfSubjectAccessReviewCollectionService) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    return this.ssarService.isAllowed('billing.appuio.io', 'billingentities', Verb.List, '');
+  }
+}

--- a/src/app/billingentity/billing-entity.guard.ts
+++ b/src/app/billingentity/billing-entity.guard.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
 import { SelfSubjectAccessReviewCollectionService } from '../store/ssar-collection.service';
 import { Verb } from '../store/app.reducer';
-import { Observable } from 'rxjs';
+import { map, Observable, tap } from 'rxjs';
+import { SelfSubjectAccessReview } from '../types/self-subject-access-review';
 
 @Injectable({
   providedIn: 'root',
@@ -12,6 +13,16 @@ export class BillingEntityGuard implements CanActivate {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    return this.ssarService.isAllowed('billing.appuio.io', 'billingentities', Verb.List, '');
+    return this.ssarService
+      .getBySelfSubjectAccessReviewLazy(
+        new SelfSubjectAccessReview(Verb.List, 'billingentities', 'billing.appuio.io', '')
+      )
+      .pipe(
+        map((ssar) => ssar.status.allowed),
+        tap((allowed) => console.log('allowed', allowed))
+      );
+    // return this.ssarService
+    //   .isAllowed('billing.appuio.io', 'billingentities', Verb.List, '')
+    //   .pipe(tap((allowed) => console.log('allowed', allowed)));
   }
 }

--- a/src/app/billingentity/billing-entity.module.ts
+++ b/src/app/billingentity/billing-entity.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { SharedModule } from '../shared/shared.module';
+import { BillingEntityComponent } from './billing-entity.component';
+import { BillingEntityRoutingModule } from './billing-entity-routing.module';
+
+@NgModule({
+  declarations: [BillingEntityComponent],
+  imports: [SharedModule, BillingEntityRoutingModule],
+})
+export default class BillingEntityModule {}

--- a/src/app/billingentity/billing-entity.module.ts
+++ b/src/app/billingentity/billing-entity.module.ts
@@ -2,9 +2,10 @@ import { NgModule } from '@angular/core';
 import { SharedModule } from '../shared/shared.module';
 import { BillingEntityComponent } from './billing-entity.component';
 import { BillingEntityRoutingModule } from './billing-entity-routing.module';
+import { BillingentityViewComponent } from './billingentity-view/billingentity-view.component';
 
 @NgModule({
-  declarations: [BillingEntityComponent],
+  declarations: [BillingEntityComponent, BillingentityViewComponent],
   imports: [SharedModule, BillingEntityRoutingModule],
 })
 export default class BillingEntityModule {}

--- a/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
+++ b/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
@@ -2,16 +2,19 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { BillingEntity } from '../../types/billing-entity';
-import { EntityCollectionService, EntityCollectionServiceFactory } from '@ngrx/data';
 import { billingEntityEntityKey } from '../../store/entity-metadata-map';
+import {
+  KubernetesCollectionService,
+  KubernetesCollectionServiceFactory,
+} from '../../store/kubernetes-collection.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BillingEntityResolver implements Resolve<BillingEntity | undefined> {
-  private billingService: EntityCollectionService<BillingEntity>;
+  private billingService: KubernetesCollectionService<BillingEntity>;
 
-  constructor(private entityFactory: EntityCollectionServiceFactory) {
+  constructor(private entityFactory: KubernetesCollectionServiceFactory) {
     this.billingService = entityFactory.create<BillingEntity>(billingEntityEntityKey);
   }
 
@@ -20,6 +23,6 @@ export class BillingEntityResolver implements Resolve<BillingEntity | undefined>
     if (!name) {
       return of(undefined);
     }
-    return this.billingService.getByKey(name);
+    return this.billingService.getByKeyMemoized(name);
   }
 }

--- a/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
+++ b/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { BillingEntity } from '../types/billing-entity';
+import { BillingEntity } from '../../types/billing-entity';
 import { EntityCollectionService, EntityCollectionServiceFactory } from '@ngrx/data';
-import { billingEntityEntityKey } from '../store/entity-metadata-map';
+import { billingEntityEntityKey } from '../../store/entity-metadata-map';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
+++ b/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
@@ -14,8 +14,8 @@ import {
 export class BillingEntityResolver implements Resolve<BillingEntity | undefined> {
   private billingService: KubernetesCollectionService<BillingEntity>;
 
-  constructor(private entityFactory: KubernetesCollectionServiceFactory) {
-    this.billingService = entityFactory.create<BillingEntity>(billingEntityEntityKey);
+  constructor(private entityFactory: KubernetesCollectionServiceFactory<BillingEntity>) {
+    this.billingService = entityFactory.create(billingEntityEntityKey);
   }
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<BillingEntity | undefined> {

--- a/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
+++ b/src/app/billingentity/billingentity-view/billing-entity-resolver.service.ts
@@ -18,6 +18,7 @@ export class BillingEntityResolver implements Resolve<BillingEntity | undefined>
     this.billingService = entityFactory.create(billingEntityEntityKey);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<BillingEntity | undefined> {
     const name = route.paramMap.get('name');
     if (!name) {

--- a/src/app/billingentity/billingentity-view/billingentity-view.component.html
+++ b/src/app/billingentity/billingentity-view/billingentity-view.component.html
@@ -1,0 +1,76 @@
+<ng-container *ngIf="billingEntity$ | ngrxPush as billingEntity; else loading">
+  <div class="surface-card p-4 shadow-2 border-round mb-4">
+    <div class="flex flex-row justify-content-between">
+      <div class="text-3xl font-medium text-900 mb-3">
+        {{ billingEntity.metadata.name }}
+      </div>
+    </div>
+    <div class="flex flex-wrap border-top-1 surface-border">
+      <ul class="w-full list-none p-0 m-0 surface-border">
+        <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
+          <div class="text-900 w-full md:w-9">
+            {{ billingEntity.spec.name }}
+          </div>
+        </li>
+        <li *ngIf="billingEntity.spec.emails" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Company Email</div>
+          <div class="text-900 w-full md:w-9">
+            <ul *ngFor="let email of billingEntity.spec.emails" class="pl-0 list-none">
+              <li>{{ email }}</li>
+            </ul>
+          </div>
+        </li>
+        <li *ngIf="billingEntity.spec.phone" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Phone</div>
+          <div class="text-900 w-full md:w-9">
+            {{ billingEntity.spec.phone }}
+          </div>
+        </li>
+        <li *ngIf="billingEntity.spec.address" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Address</div>
+          <div class="text-900 w-full md:w-9">
+            <div>{{ billingEntity.spec.address.line1 }}</div>
+            <div>{{ billingEntity.spec.address.line2 }}</div>
+            <div>{{ billingEntity.spec.address.postalCode }} {{ billingEntity.spec.address.city }}</div>
+            <div>{{ billingEntity.spec.address.country }}</div>
+          </div>
+        </li>
+        <li *ngIf="billingEntity.spec.accountingContact"
+            class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Invoice Recipient</div>
+          <div class="text-900 w-full md:w-9">
+            {{ billingEntity.spec.accountingContact.name }}
+            <ul *ngFor="let email of billingEntity.spec.accountingContact.emails" class="pl-0 list-none">
+              <li>{{ email }}</li>
+            </ul>
+          </div>
+        </li>
+        <li *ngIf="billingEntity.spec.languagePreference"
+            class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Language Preference</div>
+          <div class="text-900 w-full md:w-9">
+            {{ billingEntity.spec.languagePreference }}
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</ng-container>
+
+<ng-template #loading>
+  <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
+    <div class="flex flex-row justify-content-between">
+      <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+    </div>
+
+    <div class="flex flex-wrap border-top-1 surface-border">
+      <ul class="w-full list-none p-0 m-0 surface-border">
+        <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+          <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
+          <div class="text-900 w-full md:w-9">&#8230;</div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/billingentity/billingentity-view/billingentity-view.component.html
+++ b/src/app/billingentity/billingentity-view/billingentity-view.component.html
@@ -4,6 +4,9 @@
       <div class="text-3xl font-medium text-900 mb-3">
         {{ billingEntity.metadata.name }}
       </div>
+      <a [routerLink]="['..']" class="text-blue-500 hover:text-primary text-2xl cursor-pointer">
+        <fa-icon [icon]="faClose"></fa-icon>
+      </a>
     </div>
     <div class="flex flex-wrap border-top-1 surface-border">
       <ul class="w-full list-none p-0 m-0 surface-border">

--- a/src/app/billingentity/billingentity-view/billingentity-view.component.ts
+++ b/src/app/billingentity/billingentity-view/billingentity-view.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BillingEntity } from '../../types/billing-entity';
 import { Observable, of } from 'rxjs';
+import { faClose } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-billingentity-view',
@@ -11,6 +12,9 @@ import { Observable, of } from 'rxjs';
 })
 export class BillingentityViewComponent implements OnInit {
   billingEntity$?: Observable<BillingEntity>;
+
+  faClose = faClose;
+
   constructor(private route: ActivatedRoute) {}
 
   ngOnInit(): void {

--- a/src/app/billingentity/billingentity-view/billingentity-view.component.ts
+++ b/src/app/billingentity/billingentity-view/billingentity-view.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { BillingEntity } from '../../types/billing-entity';
+import { Observable, of } from 'rxjs';
+
+@Component({
+  selector: 'app-billingentity-view',
+  templateUrl: './billingentity-view.component.html',
+  styleUrls: ['./billingentity-view.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BillingentityViewComponent implements OnInit {
+  billingEntity$?: Observable<BillingEntity>;
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.route.data.subscribe(({ billingEntity }) => {
+      this.billingEntity$ = of(billingEntity);
+    });
+  }
+}

--- a/src/app/store/entity-metadata-map.ts
+++ b/src/app/store/entity-metadata-map.ts
@@ -7,7 +7,7 @@ import { BillingEntity } from '../types/billing-entity';
 export const organizationEntityKey = 'Organization';
 export const organizationMembersEntityKey = 'OrganizationMembers';
 export const selfSubjectAccessReviewEntityKey = 'SelfSubjectAccessReview';
-export const billingEntityEntityKey = 'BillingEntity';
+export const billingEntityEntityKey = 'billing.appuio.io/v1/billingentities';
 
 const pluralNames = {};
 export const entityMetadataMap: EntityMetadataMap = {

--- a/src/app/store/entity-metadata-map.ts
+++ b/src/app/store/entity-metadata-map.ts
@@ -2,10 +2,12 @@ import { EntityDataModuleConfig, EntityMetadataMap } from '@ngrx/data';
 import { Organization } from '../types/organization';
 import { SelfSubjectAccessReview } from '../types/self-subject-access-review';
 import { OrganizationMembers } from '../types/organization-members';
+import { BillingEntity } from '../types/billing-entity';
 
 export const organizationEntityKey = 'Organization';
 export const organizationMembersEntityKey = 'OrganizationMembers';
 export const selfSubjectAccessReviewEntityKey = 'SelfSubjectAccessReview';
+export const billingEntityEntityKey = 'BillingEntity';
 
 const pluralNames = {};
 export const entityMetadataMap: EntityMetadataMap = {
@@ -30,6 +32,12 @@ export const entityMetadataMap: EntityMetadataMap = {
     filterFn: (entities: OrganizationMembers[], filterFn: (members: OrganizationMembers) => boolean) => {
       return entities.filter((members) => filterFn(members));
     },
+  },
+  BillingEntity: {
+    entityName: billingEntityEntityKey,
+    selectId: (bEntity: BillingEntity) => bEntity.metadata.name, // cluster-scoped
+    sortComparer: (a: BillingEntity, b: BillingEntity) =>
+      a.metadata.name.localeCompare(b.metadata.name, undefined, { sensitivity: 'base' }),
   },
 };
 

--- a/src/app/store/kubernetes-collection.service.ts
+++ b/src/app/store/kubernetes-collection.service.ts
@@ -50,7 +50,7 @@ export class KubernetesCollectionService<T extends KubeObject> extends EntityCol
   public getAllMemoized(options?: EntityActionOptions): Observable<T[]> {
     return this.entities$.pipe(
       take(1),
-      switchMap((entities) => {
+      switchMap(() => {
         if (this.memoizedAllEntities) {
           return this.entities$;
         }

--- a/src/app/store/kubernetes-collection.service.ts
+++ b/src/app/store/kubernetes-collection.service.ts
@@ -1,0 +1,71 @@
+import { EntityActionOptions, EntityCollectionServiceBase, EntityCollectionServiceElementsFactory } from '@ngrx/data';
+import { KubeObject } from '../types/entity';
+import { Observable, of, take } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { buildId } from './kubernetes-data.service';
+import { Injectable } from '@angular/core';
+
+export class KubernetesCollectionService<T extends KubeObject> extends EntityCollectionServiceBase<T> {
+  constructor(entityName: string, private serviceElementsFactory: EntityCollectionServiceElementsFactory) {
+    super(entityName, serviceElementsFactory);
+  }
+
+  /**
+   * Returns the entity identified by key from the cache if it exists.
+   * If it doesn't it returns the result of {@link getByKey}.
+   * @param key the "name" or "namespace/name" of a Kubernetes resource.
+   * @param options options that influence merge behavior.
+   * @returns Observable of the queried entities after server reports successful query or the query error.
+   */
+  public getByKeyMemoized(key: string, options?: EntityActionOptions): Observable<T> {
+    return this.entities$.pipe(
+      take(1),
+      switchMap((entities: T[]) => {
+        const entity = entities.find((entity) => {
+          const entityId = buildId(entity.metadata.name, entity.metadata.namespace);
+          return entityId === key;
+        });
+        if (entity) {
+          return of(entity);
+        }
+        return super.getByKey(key, options);
+      })
+    );
+  }
+
+  /**
+   * Returns all entities from the cache if it has been loaded before.
+   * If it hasn't been loaded yet, it dispatches an action to query remote storage as in {@link EntityCollectionServiceBase.getAll}.
+   * @param options options that influence merge behavior.
+   * @returns Observable of the queried entities after server reports successful query or the query error.
+   */
+  public getAllMemoized(options?: EntityActionOptions): Observable<T[]> {
+    return this.loaded$.pipe(
+      switchMap((isLoaded) => {
+        if (isLoaded) {
+          return this.entities$;
+        }
+        return this.getAll(options);
+      })
+    );
+  }
+
+  /**
+   * Dispatches an action to get all entities from a specific Kubernetes namespace and merges the result into the cache.
+   * @param namespace to get the entities from.
+   * @param options options that influence merge behavior.
+   * @returns Observable of the queried entities after server reports successful query or the query error.
+   */
+  public getAllInNamespace(namespace: string, options?: EntityActionOptions): Observable<T[]> {
+    return this.getWithQuery({ namespace: namespace }, options);
+  }
+}
+
+@Injectable()
+export class KubernetesCollectionServiceFactory {
+  constructor(protected entityCollectionServiceElementsFactory: EntityCollectionServiceElementsFactory) {}
+
+  create<T extends KubeObject>(entityName: string): KubernetesCollectionService<T> {
+    return new KubernetesCollectionService(entityName, this.entityCollectionServiceElementsFactory);
+  }
+}

--- a/src/app/store/kubernetes-collection.service.ts
+++ b/src/app/store/kubernetes-collection.service.ts
@@ -1,13 +1,21 @@
 import { EntityActionOptions, EntityCollectionServiceBase, EntityCollectionServiceElementsFactory } from '@ngrx/data';
 import { KubeObject } from '../types/entity';
-import { Observable, of, take } from 'rxjs';
+import { Observable, of, take, tap } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { buildId } from './kubernetes-data.service';
 import { Injectable } from '@angular/core';
 
 export class KubernetesCollectionService<T extends KubeObject> extends EntityCollectionServiceBase<T> {
+  // this flags holds the value true where there was an initial collection load.
+  // Ideally this can be done with rxJS, but it's not easy to accomplish this if there is no initial QUERY_ALL action dispatched.
+  private memoizedAllEntities = false;
+
   constructor(entityName: string, private serviceElementsFactory: EntityCollectionServiceElementsFactory) {
     super(entityName, serviceElementsFactory);
+  }
+
+  override getAll(options?: EntityActionOptions): Observable<T[]> {
+    return super.getAll(options).pipe(tap(() => (this.memoizedAllEntities = true)));
   }
 
   /**
@@ -40,9 +48,10 @@ export class KubernetesCollectionService<T extends KubeObject> extends EntityCol
    * @returns Observable of the queried entities after server reports successful query or the query error.
    */
   public getAllMemoized(options?: EntityActionOptions): Observable<T[]> {
-    return this.loaded$.pipe(
-      switchMap((isLoaded) => {
-        if (isLoaded) {
+    return this.entities$.pipe(
+      take(1),
+      switchMap((entities) => {
+        if (this.memoizedAllEntities) {
           return this.entities$;
         }
         return this.getAll(options);
@@ -62,10 +71,20 @@ export class KubernetesCollectionService<T extends KubeObject> extends EntityCol
 }
 
 @Injectable()
-export class KubernetesCollectionServiceFactory {
+export class KubernetesCollectionServiceFactory<T extends KubeObject> {
+  protected knownCollectionServices: Map<string, KubernetesCollectionService<T>> = new Map<
+    string,
+    KubernetesCollectionService<T>
+  >();
   constructor(protected entityCollectionServiceElementsFactory: EntityCollectionServiceElementsFactory) {}
 
-  create<T extends KubeObject>(entityName: string): KubernetesCollectionService<T> {
-    return new KubernetesCollectionService(entityName, this.entityCollectionServiceElementsFactory);
+  create(entityName: string): KubernetesCollectionService<T> {
+    let knownService = this.knownCollectionServices.get(entityName);
+    if (knownService) {
+      return knownService;
+    }
+    knownService = new KubernetesCollectionService(entityName, this.entityCollectionServiceElementsFactory);
+    this.knownCollectionServices.set(entityName, knownService);
+    return knownService;
   }
 }

--- a/src/app/store/kubernetes-data.service.ts
+++ b/src/app/store/kubernetes-data.service.ts
@@ -1,0 +1,99 @@
+import { EntityCollectionDataService, HttpMethods, QueryParams } from '@ngrx/data';
+import { KubeObject } from '../types/entity';
+import { map, Observable } from 'rxjs';
+import { Update } from '@ngrx/entity';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { KubernetesUrlGenerator } from './kubernetes-url-generator.service';
+
+export declare type Operation = 'CREATE' | 'READ' | 'UPDATE' | 'DELETE';
+
+export class KubernetesDataService<T extends KubeObject> implements EntityCollectionDataService<T> {
+  protected _name: string;
+
+  constructor(entityName: string, protected http: HttpClient, protected urlGenerator: KubernetesUrlGenerator) {
+    this._name = entityName;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  getWithQuery(params: QueryParams | string): Observable<T[]> {
+    return this.executeCollection('GET', this.urlGenerator.getEntityList(this.name, 'READ', params), params);
+  }
+
+  upsert(entity: T): Observable<T> {
+    throw new Error('not implemented in Kubernetes');
+  }
+
+  add(entity: T): Observable<T> {
+    return this.execute('POST', this.urlGenerator.getEntity(this.name, this.buildId(entity), 'CREATE'));
+  }
+
+  delete(id: number | string): Observable<number | string> {
+    return this.execute('DELETE', this.urlGenerator.getEntity(this.name, id.toString(), 'DELETE')).pipe(
+      map((t) => t.metadata.name)
+    );
+  }
+
+  /*
+  Gets all entities across the cluster.
+  Note: This doesn't work for namespaced collections.
+  For namespaced collections, use "getWithQuery" and set the "namespace" parameter.
+  */
+  getAll(): Observable<T[]> {
+    return this.executeCollection('GET', this.urlGenerator.getEntityList(this.name, 'READ'));
+  }
+
+  getById(id: string): Observable<T> {
+    return this.execute('GET', this.urlGenerator.getEntity(this.name, id, 'READ'));
+  }
+
+  update(update: Update<T>): Observable<T> {
+    const entity = update.changes as T;
+    return this.execute('PUT', this.urlGenerator.getEntity(this.name, update.id.toString(), 'UPDATE'), entity);
+  }
+
+  protected executeCollection(method: HttpMethods, url: string, queryParams?: QueryParams | string): Observable<T[]> {
+    const qParams = typeof queryParams === 'string' ? { fromString: queryParams } : { fromObject: queryParams };
+    const params = new HttpParams(qParams);
+    switch (method) {
+      case 'GET': {
+        return this.http
+          .get<{ items: T[] }>(url, { params: params, responseType: 'json' })
+          .pipe(map((list) => list.items));
+      }
+      default: {
+        throw new Error(`Unimplemented HTTP method for collections: ${method}`);
+      }
+    }
+  }
+
+  protected execute(method: HttpMethods, url: string, data?: T): Observable<T> {
+    switch (method) {
+      case 'DELETE': {
+        return this.http.delete<T>(url);
+      }
+      case 'GET': {
+        return this.http.get<T>(url);
+      }
+      case 'POST': {
+        return this.http.post<T>(url, data);
+      }
+      case 'PUT': {
+        return this.http.put<T>(url, data);
+      }
+      default: {
+        throw new Error(`Unimplemented HTTP method: ${method}`);
+      }
+    }
+  }
+
+  protected buildId(entity: T): string {
+    let id = entity.metadata.name;
+    if (entity.metadata.namespace) {
+      id = `${entity.metadata.namespace}/${entity.metadata.name}`;
+    }
+    return id;
+  }
+}

--- a/src/app/store/kubernetes-data.service.ts
+++ b/src/app/store/kubernetes-data.service.ts
@@ -23,6 +23,7 @@ export class KubernetesDataService<T extends KubeObject> implements EntityCollec
     return this.executeCollection('GET', this.urlGenerator.getEntityList(this.name, 'READ', params), params);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   upsert(entity: T): Observable<T> {
     throw new Error('not implemented in Kubernetes');
   }

--- a/src/app/store/kubernetes-url-generator.service.ts
+++ b/src/app/store/kubernetes-url-generator.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@angular/core';
+import { Operation } from './kubernetes-data.service';
+import { billingEntityEntityKey } from './entity-metadata-map';
+import { QueryParams } from '@ngrx/data';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class KubernetesUrlGenerator {
+  protected readonly apiPrefix = 'appuio-api';
+  protected knownEntities: Map<string, { apiVersion: string; kind: string }> = new Map<
+    string,
+    { apiVersion: string; kind: string }
+  >();
+
+  constructor() {
+    this.knownEntities.set(billingEntityEntityKey, { apiVersion: 'billing.appuio.io/v1', kind: 'billingentities' });
+  }
+
+  getEntity(entityName: string, id: string, op: Operation): string {
+    const meta = this.knownEntities.get(entityName);
+    if (!meta) {
+      throw new Error(`Entity "${entityName}" is not registered in the Kubernetes URL generator`);
+    }
+    const idSplit = this.splitID(id);
+    if (idSplit.namespace && idSplit.namespace !== '') {
+      // we have an ID that contains name + namespace.
+      const base = `${this.apiPrefix}/apis/${meta.apiVersion}/namespaces/${idSplit.namespace}/${meta.kind}`;
+      switch (op) {
+        case 'CREATE': {
+          return base; // the name is not part of the endpoint for new objects, but in the payload.
+        }
+        default: {
+          return `${base}/${idSplit.name}`;
+        }
+      }
+    }
+    // this case is for cluster-scoped resources.
+    return `${this.apiPrefix}/apis/${meta.apiVersion}/${meta.kind}/${idSplit.name}`;
+  }
+
+  getEntityList(entityName: string, op: Operation, queryParams?: QueryParams | string): string {
+    const meta = this.knownEntities.get(entityName);
+    if (!meta) {
+      throw new Error(`Entity "${entityName}" is not registered in the Kubernetes URL generator`);
+    }
+
+    if (queryParams && typeof queryParams !== 'string') {
+      const namespace = queryParams['namespace'];
+      if (namespace && namespace !== '') {
+        delete queryParams['namespace'];
+        // Scope the list to a specific namespace for namespace-scoped resources.
+        return `${this.apiPrefix}/apis/${meta.apiVersion}/namespaces/${namespace}/${meta.kind}`;
+      }
+    }
+    // all cluster-scoped objects, or objects from all namespaces.
+    return `${this.apiPrefix}/apis/${meta.apiVersion}/${meta.kind}`;
+  }
+
+  protected splitID(id: string): { name: string; namespace?: string } {
+    const arr = id.split('/');
+    if (arr.length === 1) {
+      return { name: arr[0] };
+    }
+    if (arr.length === 2) {
+      return { name: arr[1], namespace: arr[0] };
+    }
+    throw new Error(`id is an invalid Kubernetes name, must be one of ["name", "namespace/name"], : ${id}`);
+  }
+}

--- a/src/app/store/kubernetes-url-generator.service.ts
+++ b/src/app/store/kubernetes-url-generator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Operation } from './kubernetes-data.service';
+import { Operation, splitID } from './kubernetes-data.service';
 import { QueryParams } from '@ngrx/data';
 
 @Injectable({
@@ -17,7 +17,7 @@ export class KubernetesUrlGenerator {
     if (!meta) {
       throw new Error(`Entity "${entityName}" is not registered in the Kubernetes URL generator`);
     }
-    const idSplit = this.splitID(id);
+    const idSplit = splitID(id);
     if (idSplit.namespace && idSplit.namespace !== '') {
       // we have an ID that contains name + namespace.
       const base = `${this.apiPrefix}/apis/${meta.apiVersion}/namespaces/${idSplit.namespace}/${meta.kind}`;
@@ -50,17 +50,6 @@ export class KubernetesUrlGenerator {
     }
     // all cluster-scoped objects, or objects from all namespaces.
     return `${this.apiPrefix}/apis/${meta.apiVersion}/${meta.kind}`;
-  }
-
-  protected splitID(id: string): { name: string; namespace?: string } {
-    const arr = id.split('/');
-    if (arr.length === 1) {
-      return { name: arr[0] };
-    }
-    if (arr.length === 2) {
-      return { name: arr[1], namespace: arr[0] };
-    }
-    throw new Error(`id is an invalid Kubernetes name, must be one of ["name", "namespace/name"], : ${id}`);
   }
 
   protected getKubeObjectMeta(entityName: string): { apiVersion: string; kind: string } {

--- a/src/app/store/ssar-collection.service.ts
+++ b/src/app/store/ssar-collection.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { EntityCollectionServiceBase, EntityCollectionServiceElementsFactory } from '@ngrx/data';
 import { composeSsarId, selfSubjectAccessReviewEntityKey } from './entity-metadata-map';
 import { SelfSubjectAccessReview } from '../types/self-subject-access-review';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -10,6 +10,12 @@ import { Observable } from 'rxjs';
 export class SelfSubjectAccessReviewCollectionService extends EntityCollectionServiceBase<SelfSubjectAccessReview> {
   constructor(private elementsFactory: EntityCollectionServiceElementsFactory) {
     super(selfSubjectAccessReviewEntityKey, elementsFactory);
+  }
+
+  public isAllowed(group: string, resource: string, verb: string, namespace?: string): Observable<boolean> {
+    return this.entities$.pipe(
+      map((ssars) => ssars.some((ssar) => this.isMatchingAndAllowed(ssar, group, resource, namespace ?? '', verb)))
+    );
   }
 
   public isMatchingAndAllowed(

--- a/src/app/store/ssar-data.service.ts
+++ b/src/app/store/ssar-data.service.ts
@@ -3,9 +3,8 @@ import { SelfSubjectAccessReview } from '../types/self-subject-access-review';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { KubernetesClientService } from '../core/kubernetes-client.service';
-import { composeSsarId, decomposeSsarId, selfSubjectAccessReviewEntityKey } from './entity-metadata-map';
+import { decomposeSsarId, selfSubjectAccessReviewEntityKey } from './entity-metadata-map';
 import { HttpClient } from '@angular/common/http';
-import { Verb } from './app.reducer';
 
 @Injectable({ providedIn: 'root' })
 export class SelfSubjectAccessReviewDataService extends DefaultDataService<SelfSubjectAccessReview> {
@@ -18,9 +17,3 @@ export class SelfSubjectAccessReviewDataService extends DefaultDataService<SelfS
     return this.kubeService.getSelfSubjectAccessReview(attr.namespace, attr.resource, attr.group, attr.verb);
   }
 }
-
-export const clusterOrganizationSsarIDs = [
-  composeSsarId(new SelfSubjectAccessReview(Verb.List, 'organizations', 'rbac.appuio.io', '')),
-  composeSsarId(new SelfSubjectAccessReview(Verb.Create, 'organizations', 'rbac.appuio.io', '')),
-  composeSsarId(new SelfSubjectAccessReview(Verb.Update, 'organizations', 'rbac.appuio.io', '')),
-];

--- a/src/app/types/billing-entity.ts
+++ b/src/app/types/billing-entity.ts
@@ -1,0 +1,36 @@
+import { KubeObject } from './entity';
+
+export interface BillingEntity extends KubeObject {
+  kind: 'BillingEntity';
+  apiVersion: 'billing.appuio.io/v1';
+  spec: BillingEntitySpec;
+}
+
+export interface BillingEntitySpec {
+  name?: string;
+  phone?: string;
+  emails?: string[];
+  address?: BillingEntityAddress;
+  accountingContact?: BillingEntityContact;
+  languagePreference?: string;
+}
+
+export interface BillingEntityAddress {
+  line1?: string;
+  line2?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+export interface BillingEntityContact {
+  name?: string;
+  emails?: string[];
+}
+
+export interface BillingEntityList {
+  kind: 'BillingEntityList';
+  apiVersion: 'billing.appuio.io/v1';
+  metadata: object;
+  items: BillingEntity[];
+}

--- a/src/app/types/entity.ts
+++ b/src/app/types/entity.ts
@@ -9,3 +9,13 @@ export interface Entity<ValueType> {
   state: EntityState;
   value: ValueType;
 }
+
+export interface KubeObject {
+  metadata: {
+    name: string;
+    namespace?: string;
+    [key: string]: unknown;
+  };
+  kind: string;
+  apiVersion: string;
+}


### PR DESCRIPTION
## Summary

Part 1 of #438 

This PR introduces the feature to list billing entities under `/billingentities`, provided the user has access to view those.

Under the hood, this PR extends on #482 by implementing a generic ngrx/data-backed Kubernetes resource service.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
