### PR TITLE
Renovate: Set group name for minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
           "digest"
         ],
         "automerge": true,
+        "groupName": "npm",
         "schedule": [
           "on the first day of the week"
         ]
@@ -24,7 +25,7 @@
         "matchUpdateTypes": [
           "major"
         ],
-        "groupName": "npm",
+        "groupName": "npm-major",
         "schedule": [
           "on the first day of the week"
         ]


### PR DESCRIPTION


## Summary

Should reduce renovate noise by grouping minor updates together once per week.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
