### PR TITLE
Create Invitations

### DIFF
--- a/cypress/e2e/invitations-create.cy.ts
+++ b/cypress/e2e/invitations-create.cy.ts
@@ -1,0 +1,311 @@
+import { createUser } from '../fixtures/user';
+import { Invitation, InvitationPermissions, InvitationSpec } from '../../src/app/types/invitation';
+import { BillingEntityPermissions } from '../../src/app/types/billing-entity';
+import { OrganizationPermissions } from '../../src/app/types/organization';
+import { organizationNxt, organizationVshn, setOrganization } from '../fixtures/organization';
+import { billingEntityNxt, setBillingEntities } from '../fixtures/billingentities';
+import { createInvitation } from '../fixtures/invitations';
+import { createTeam, setTeam, team1 } from '../fixtures/team';
+
+describe('Test invitation create', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // needed for initial getUser request
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig' }),
+    });
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...BillingEntityPermissions },
+      { verb: 'list', ...OrganizationPermissions }
+    );
+  });
+
+  it('should make fields required', () => {
+    setOrganization(cy, organizationNxt);
+    setBillingEntities(cy);
+    setTeam(cy, 'nxt');
+
+    cy.visit('/invitations/create');
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('button[type=submit]').should('be.disabled');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('button[type=submit]').should('be.enabled').click();
+    cy.get('.p-error').should('contain.text', 'Please select at least one element');
+  });
+
+  it('should select organization without team and roles', () => {
+    setOrganization(cy, organizationNxt);
+    setBillingEntities(cy);
+    setTeam(cy, 'nxt');
+    cy.intercept('POST', 'appuio-api/apis/user.appuio.io/v1/invitations', {
+      body: createInvitation({}),
+    }).as('createInvitation');
+
+    cy.visit('/invitations/create');
+
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('p-checkbox input').should('be.disabled');
+    cy.get('p-dropdown').eq(0).click().contains('nxt').click();
+    cy.get('button[type=submit]').should('be.enabled').click();
+
+    cy.wait('@createInvitation')
+      .its('request.body')
+      .then((body: Invitation) => {
+        const spec = body.spec;
+
+        console.debug('received spec', spec);
+        const expectedSpec: InvitationSpec = createInvitation({
+          organizations: [{ name: 'nxt' }],
+        }).spec;
+        expectedSpec.note = '';
+        console.debug('expected spec', expectedSpec);
+        expect(spec).deep.eq(expectedSpec);
+      });
+  });
+
+  it('should select organization with team and roles', () => {
+    setOrganization(cy, organizationNxt);
+    setBillingEntities(cy);
+    setTeam(cy, 'nxt', team1);
+    cy.intercept('POST', 'appuio-api/apis/user.appuio.io/v1/invitations', {
+      body: createInvitation({}),
+    }).as('createInvitation');
+
+    cy.visit('/invitations/create');
+
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('#note').type('New Employee working for 👁️');
+
+    cy.get('p-checkbox input').should('be.disabled');
+    cy.get('p-dropdown').eq(0).click().contains('nxt').click();
+    cy.get('p-checkbox').eq(0).click();
+    cy.get('p-multiselect').eq(0).click().contains('team1').click();
+    cy.get('button[type=submit]').should('be.enabled').click();
+
+    cy.wait('@createInvitation')
+      .its('request.body')
+      .then((body: Invitation) => {
+        const spec = body.spec;
+
+        console.debug('received spec', spec);
+        const expectedSpec: InvitationSpec = createInvitation({
+          organizations: [{ name: 'nxt', role: 'viewer', teams: ['team1'] }],
+        }).spec;
+        console.debug('expected spec', expectedSpec);
+        expect(spec).deep.eq(expectedSpec);
+      });
+  });
+
+  it('should switch teams per organization', () => {
+    setOrganization(cy, organizationNxt, organizationVshn);
+    setBillingEntities(cy);
+    setTeam(cy, 'nxt', team1);
+    setTeam(
+      cy,
+      'vshn',
+      createTeam({ namespace: 'vshn', name: 'ops-team' }),
+      createTeam({ namespace: 'vshn', name: 'another' })
+    );
+
+    cy.visit('/invitations/create');
+
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('#note').type('New Employee working for 👁️');
+
+    cy.get('p-dropdown').eq(0).click().contains('nxt').click();
+    cy.get('p-multiselect').eq(0).click().contains('Super').click();
+    cy.get('p-dropdown').eq(0).click().contains('DevOps').click();
+    cy.get('p-multiselect').eq(0).should('contain.text', 'Select Team');
+    cy.get('p-multiselect').eq(0).click().contains('ops-team').click();
+    cy.get('p-multiselect').eq(0).contains('another').click();
+  });
+
+  it('should select billing', () => {
+    setOrganization(cy);
+    setBillingEntities(cy, billingEntityNxt);
+    cy.intercept('POST', 'appuio-api/apis/user.appuio.io/v1/invitations', {
+      body: createInvitation({}),
+    }).as('createInvitation');
+
+    cy.visit('/invitations/create');
+
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('#note').type('New Employee working for 👁️');
+
+    cy.get('p-checkbox input').should('be.disabled');
+    cy.get('p-dropdown').eq(0).click().contains('be-2345').click();
+    cy.get('p-checkbox').eq(0).click();
+    cy.get('button[type=submit]').should('be.enabled').click();
+
+    cy.wait('@createInvitation')
+      .its('request.body')
+      .then((body: Invitation) => {
+        const spec = body.spec;
+
+        console.debug('received spec', spec);
+        const expectedSpec: InvitationSpec = createInvitation({
+          billingEntities: [{ name: 'be-2345', role: 'viewer' }],
+        }).spec;
+        console.debug('expected spec', expectedSpec);
+        expect(spec).deep.eq(expectedSpec);
+      });
+  });
+
+  it('should select billing role', () => {
+    setOrganization(cy);
+    setBillingEntities(cy, billingEntityNxt);
+
+    cy.visit('/invitations/create');
+
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#email').type('dev@nxt.engineering');
+    cy.get('#note').type('New Employee working for 👁️');
+
+    cy.get('p-checkbox input').should('be.disabled');
+    cy.get('p-dropdown').eq(0).click().contains('be-2345').click();
+    cy.get('small.p-error').should('contain.text', 'Select at least one role');
+    cy.get('p-checkbox input').should('be.enabled');
+    cy.get('button[type=submit]').should('be.disabled');
+
+    cy.get('p-checkbox').eq(1).click();
+    cy.get('button[type=submit]').should('be.enabled'); // admin selected
+    cy.get('p-checkbox').eq(0).click();
+    cy.get('button[type=submit]').should('be.enabled'); // both selected
+    cy.get('p-checkbox').eq(1).click();
+    cy.get('button[type=submit]').should('be.enabled'); // viewer selected (admin unselected)
+    cy.get('p-checkbox').eq(0).click();
+    cy.get('button[type=submit]').should('be.disabled'); // none selected
+
+    cy.get('p-dropdown').eq(1).should('exist');
+    cy.get('button[type=button').click();
+    cy.get('p-dropdown').eq(1).should('not.exist');
+    cy.get('button[type=submit]').should('be.enabled');
+  });
+});
+
+describe('limited permissions', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // needed for initial getUser request
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig', defaultOrganizationRef: 'nxt' }),
+    });
+  });
+
+  it('no list permission', () => {
+    cy.setPermission({ verb: 'list', ...InvitationPermissions }, { verb: 'create', ...InvitationPermissions });
+    cy.visit('/invitations/create');
+    cy.get('#no-permissions').should(
+      'contain.text',
+      'You cannot invite users without having enough permissions by yourself'
+    );
+  });
+
+  it('no organizations or billing entities available', () => {
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions }
+    );
+    setOrganization(cy);
+    setBillingEntities(cy);
+
+    cy.visit('/invitations/create');
+    cy.get('#no-permissions').should(
+      'contain.text',
+      'You cannot invite users without having enough permissions by yourself'
+    );
+  });
+
+  it('only billing list permissions', () => {
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...BillingEntityPermissions }
+    );
+    setBillingEntities(cy, billingEntityNxt);
+
+    cy.visit('/invitations/create');
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#organizationFormGroup').should('not.exist');
+    cy.get('#billingFormGroup').should('exist');
+  });
+
+  it('only organization list permissions', () => {
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...OrganizationPermissions }
+    );
+    setOrganization(cy, organizationVshn);
+    setTeam(cy, 'vshn');
+
+    cy.visit('/invitations/create');
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#organizationFormGroup').should('exist');
+    cy.get('#billingFormGroup').should('not.exist');
+  });
+
+  it('only organization and team list permissions', () => {
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...OrganizationPermissions }
+    );
+    setOrganization(cy, organizationNxt);
+    setTeam(cy, 'nxt', team1);
+
+    cy.visit('/invitations/create');
+    cy.wait('@teamList-nxt');
+    cy.get('#title').should('contain.text', 'Invite User');
+    cy.get('#organizationFormGroup').should('exist');
+    cy.get('#billingFormGroup').should('not.exist');
+  });
+});
+
+describe('degradation', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // needed for initial getUser request
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig', defaultOrganizationRef: 'nxt' }),
+    });
+  });
+
+  it('failed billing entities', () => {
+    cy.setPermission(
+      { verb: 'list', ...InvitationPermissions },
+      { verb: 'create', ...InvitationPermissions },
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions }
+    );
+    setOrganization(cy, organizationNxt);
+    setTeam(cy, 'nxt');
+    cy.intercept('GET', 'appuio-api/apis/billing.appuio.io/v1/billingentities', {
+      statusCode: 503,
+    });
+
+    cy.visit('/invitations/create');
+    cy.get('#organizationFormGroup').should('exist');
+    cy.get('#billingFormGroup').should('not.exist');
+  });
+});

--- a/cypress/e2e/invitations-create.cy.ts
+++ b/cypress/e2e/invitations-create.cy.ts
@@ -307,5 +307,6 @@ describe('degradation', () => {
     cy.visit('/invitations/create');
     cy.get('#organizationFormGroup').should('exist');
     cy.get('#billingFormGroup').should('not.exist');
+    cy.get('#warning-message').should('contain.text', 'Billing Entities could not be loaded at the moment.');
   });
 });

--- a/cypress/e2e/invitations.cy.ts
+++ b/cypress/e2e/invitations.cy.ts
@@ -49,7 +49,6 @@ describe('Test invitation list', () => {
       statusCode: 403,
     });
     cy.visit('/invitations');
-    cy.get('#title').should('contain.text', 'Invitations');
     cy.get('#failure-message').should('contain.text', 'Invitations could not be loaded.');
   });
 

--- a/cypress/e2e/invitations.cy.ts
+++ b/cypress/e2e/invitations.cy.ts
@@ -111,7 +111,7 @@ describe('invitation details', () => {
   it('displays single properties', () => {
     cy.intercept('GET', 'appuio-api/apis/user.appuio.io/v1/invitations', {
       body: {
-        items: [createInvitation({ email: 'sent' })],
+        items: [createInvitation({ email: 'sent', hasStatus: true })],
       },
     });
     cy.visit('/invitations');
@@ -133,7 +133,7 @@ describe('invitation details', () => {
   it('displays failed condition', () => {
     cy.intercept('GET', 'appuio-api/apis/user.appuio.io/v1/invitations', {
       body: {
-        items: [createInvitation({ email: 'sendFailed' })],
+        items: [createInvitation({ email: 'sendFailed', hasStatus: true })],
       },
     });
     cy.visit('/invitations');
@@ -156,6 +156,7 @@ describe('invitation details', () => {
               { name: 'vshn', role: 'viewer', teams: ['dev-team', 'ops-team'] },
             ],
             billingEntities: [{ name: 'be-2345', role: 'both' }],
+            hasStatus: true,
           }),
         ],
       },

--- a/cypress/fixtures/organization.ts
+++ b/cypress/fixtures/organization.ts
@@ -10,17 +10,13 @@ export const organizationVshn = createOrganization({
   name: 'vshn',
   displayName: 'VSHN - the DevOps Company',
 });
+export const organizationNxt = createOrganization({
+  name: 'nxt',
+  displayName: 'nxt Engineering GmbH',
+});
 
 export const organizationListNxtVshn = {
-  items: [
-    createOrganization({
-      name: 'nxt',
-      displayName: 'nxt Engineering GmbH',
-    }),
-    createOrganization({
-      name: 'vshn',
-    }),
-  ],
+  items: [organizationNxt, organizationVshn],
 };
 
 export const organizationListNxtVshnWithDisplayName = {

--- a/cypress/fixtures/team.ts
+++ b/cypress/fixtures/team.ts
@@ -4,8 +4,8 @@ import { List } from '../../src/app/types/list';
 export interface TeamConfig {
   name: string;
   namespace: string;
-  displayName: string;
-  userRefs: UserRef[];
+  displayName?: string;
+  userRefs?: UserRef[];
 }
 
 export interface TeamListConfig {
@@ -55,8 +55,8 @@ export function createTeam(teamConfig: TeamConfig): Team {
       namespace: teamConfig.namespace,
     },
     spec: {
-      displayName: teamConfig.displayName,
-      userRefs: teamConfig.userRefs,
+      displayName: teamConfig.displayName ? teamConfig.displayName : '',
+      userRefs: teamConfig.userRefs ? teamConfig.userRefs : [],
     },
   };
 }
@@ -71,4 +71,10 @@ export function createTeamList(teamListConfig: TeamListConfig): List<Team> {
       selfLink: '',
     },
   };
+}
+
+export function setTeam(cy: Cypress.cy, namespace: string, ...teams: Team[]): void {
+  cy.intercept('GET', `appuio-api/apis/appuio.io/v1/namespaces/${namespace}/teams`, {
+    body: { items: [...teams] },
+  }).as(`teamList-${namespace}`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "rxjs": "7.8.0",
         "ts-md5": "1.3.1",
         "tslib": "2.5.0",
+        "uuid": "9.0.0",
         "zone.js": "0.12.0"
       },
       "devDependencies": {
@@ -51,6 +52,7 @@
         "@ngrx/schematics": "15.3.0",
         "@types/jest": "29.4.0",
         "@types/node": "18.14.6",
+        "@types/uuid": "9.0.1",
         "@typescript-eslint/eslint-plugin": "5.54.0",
         "@typescript-eslint/parser": "5.54.0",
         "angular-http-server": "1.11.1",
@@ -2599,6 +2601,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/schematic": {
@@ -5587,6 +5598,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -19914,6 +19931,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -21079,10 +21105,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -23545,6 +23570,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "@cypress/schematic": {
@@ -25796,6 +25829,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/ws": {
@@ -36560,6 +36599,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -37438,10 +37485,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rxjs": "7.8.0",
     "ts-md5": "1.3.1",
     "tslib": "2.5.0",
+    "uuid": "9.0.0",
     "zone.js": "0.12.0"
   },
   "devDependencies": {
@@ -61,6 +62,7 @@
     "@ngrx/schematics": "15.3.0",
     "@types/jest": "29.4.0",
     "@types/node": "18.14.6",
+    "@types/uuid": "9.0.1",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
     "angular-http-server": "1.11.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -128,5 +128,4 @@ export const authCodeFlowConfig: AuthConfig = {
   redirectUri: window.location.origin + window.location.pathname,
   responseType: 'code',
   scope: 'openid profile email roles offline_access web-origins',
-  showDebugInformation: !environment.production,
 };

--- a/src/app/invitations/invitation-edit/invitation-edit.component.html
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.html
@@ -10,6 +10,9 @@
         </a>
       </div>
       <div class="border-top-1 surface-border">
+        <div *ngIf="payload.billingEntitiesFailed" id="warning-message" class="col-12 mb-2">
+          <p-message i18n-text severity="warn" text="Billing Entities could not be loaded at the moment. Try again or create a separate invite later."></p-message>
+        </div>
         <app-invitation-form
           [organizations]="payload.organizations"
           [canInviteOrganization]="payload.canViewOrganizations"

--- a/src/app/invitations/invitation-edit/invitation-edit.component.html
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.html
@@ -1,0 +1,50 @@
+<ng-container *ngrxLet="payload$ as payload; suspenseTpl: loading; error as err">
+  <ng-container *ngIf="payload">
+    <div *ngIf="payload.canViewOrganizations || payload.canViewBillingEntities; else nothingToInvite" class="surface-card p-4 shadow-2 border-round mb-4">
+      <div class="flex flex-row justify-content-between">
+        <div id="title" class="text-3xl font-medium text-900 mb-3">
+          <span i18n>Invite User</span>
+        </div>
+        <a [routerLink]="['..']" class="text-blue-500 hover:text-primary text-2xl cursor-pointer">
+          <fa-icon [icon]="faClose"></fa-icon>
+        </a>
+      </div>
+      <div class="border-top-1 surface-border">
+        <app-invitation-form
+          [organizations]="payload.organizations"
+          [canInviteOrganization]="payload.canViewOrganizations"
+          [billingEntities]="payload.billingEntities"
+          [canInviteBilling]="payload.canViewBillingEntities"
+          [teams]="payload.teams"
+        />
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="err">
+    <p-messages severity="error">
+      <ng-template pTemplate="content">
+        <fa-icon [icon]="faWarning" />
+        <div class="ml-2" i18n id="failure-message">Data required for inviting users could not be loaded.</div>
+      </ng-template>
+    </p-messages>
+  </ng-container>
+
+</ng-container>
+
+<ng-template #loading>
+  <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
+    <div class="flex flex-row justify-content-between">
+      <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #nothingToInvite>
+  <p-messages severity="warn">
+    <ng-template pTemplate="content">
+      <fa-icon [icon]="faWarning" />
+      <div class="ml-2" i18n id="no-permissions">You cannot invite users without having enough permissions by yourself</div>
+    </ng-template>
+  </p-messages>
+</ng-template>

--- a/src/app/invitations/invitation-edit/invitation-edit.component.ts
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.ts
@@ -34,7 +34,7 @@ export class InvitationEditComponent implements OnInit {
     ]).pipe(
       switchMap(([canViewOrganizations, canViewBillingEntities]) => {
         const organizations$ = canViewOrganizations ? this.organizationService.getAllMemoized().pipe(take(1)) : of([]);
-        const billingEntities$ = canViewBillingEntities ? this.billingService.getAllMemoized().pipe(take(1)) : of([]);
+        const billingEntities$ = canViewBillingEntities ? this.fetchBilling$() : of([]);
         return forkJoin([of(canViewOrganizations), organizations$, of(canViewBillingEntities), billingEntities$]);
       }),
       switchMap(([canViewOrganizations, organizations, canViewBillingEntities, billingEntities]) => {
@@ -55,6 +55,13 @@ export class InvitationEditComponent implements OnInit {
           teams,
         } satisfies Payload;
       })
+    );
+  }
+
+  private fetchBilling$(): Observable<BillingEntity[]> {
+    return this.billingService.getAllMemoized().pipe(
+      take(1),
+      catchError(() => of([])) // swallows all kinds of errors.
     );
   }
 

--- a/src/app/invitations/invitation-edit/invitation-edit.component.ts
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.ts
@@ -50,18 +50,19 @@ export class InvitationEditComponent implements OnInit {
         return {
           canViewOrganizations: canViewOrganizations && organizations.length > 0,
           organizations,
-          canViewBillingEntities: canViewBillingEntities && billingEntities.length > 0,
-          billingEntities,
+          canViewBillingEntities: canViewBillingEntities && billingEntities ? billingEntities.length > 0 : false,
+          billingEntities: billingEntities ?? [],
+          billingEntitiesFailed: billingEntities === undefined,
           teams,
         } satisfies Payload;
       })
     );
   }
 
-  private fetchBilling$(): Observable<BillingEntity[]> {
+  private fetchBilling$(): Observable<BillingEntity[] | undefined> {
     return this.billingService.getAllMemoized().pipe(
       take(1),
-      catchError(() => of([])) // swallows all kinds of errors.
+      catchError(() => of(undefined)) // swallows all kinds of errors.
     );
   }
 
@@ -89,5 +90,6 @@ interface Payload {
   organizations: Organization[];
   canViewBillingEntities: boolean;
   billingEntities: BillingEntity[];
+  billingEntitiesFailed: boolean;
   teams: Team[];
 }

--- a/src/app/invitations/invitation-edit/invitation-edit.component.ts
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.ts
@@ -1,0 +1,95 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { faClose, faWarning } from '@fortawesome/free-solid-svg-icons';
+import { OrganizationCollectionService } from '../../store/organization-collection.service';
+import { BillingEntityCollectionService } from '../../store/billingentity-collection.service';
+import { catchError, combineLatestAll, forkJoin, from, map, Observable, of, switchMap, take } from 'rxjs';
+import { Organization } from '../../types/organization';
+import { BillingEntity } from '../../types/billing-entity';
+import { TeamCollectionService } from '../../store/team-collection.service';
+import { Team } from '../../types/team';
+import { defaultIfStatusCode } from '../../store/kubernetes-collection.service';
+
+@Component({
+  selector: 'app-invitation-edit',
+  templateUrl: './invitation-edit.component.html',
+  styleUrls: ['./invitation-edit.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InvitationEditComponent implements OnInit {
+  payload$?: Observable<Payload>;
+
+  faClose = faClose;
+  faWarning = faWarning;
+
+  constructor(
+    private organizationService: OrganizationCollectionService,
+    private billingService: BillingEntityCollectionService,
+    private teamService: TeamCollectionService
+  ) {}
+
+  ngOnInit(): void {
+    this.payload$ = forkJoin([
+      this.organizationService.canViewOrganizations$,
+      this.billingService.canViewBillingEntities$,
+    ]).pipe(
+      switchMap(([canViewOrganizations, canViewBillingEntities]) => {
+        const organizations$ = canViewOrganizations ? this.organizationService.getAllMemoized().pipe(take(1)) : of([]);
+        const billingEntities$ = canViewBillingEntities ? this.billingService.getAllMemoized().pipe(take(1)) : of([]);
+        return forkJoin([of(canViewOrganizations), organizations$, of(canViewBillingEntities), billingEntities$]);
+      }),
+      switchMap(([canViewOrganizations, organizations, canViewBillingEntities, billingEntities]) => {
+        return forkJoin([
+          of(canViewOrganizations),
+          of(organizations),
+          of(canViewBillingEntities),
+          of(billingEntities),
+          this.fetchTeamsFromAllOrganizations(organizations),
+        ]);
+      }),
+      map(([canViewOrganizations, organizations, canViewBillingEntities, billingEntities, teams]) => {
+        return {
+          canViewOrganizations: canViewOrganizations && organizations.length > 0,
+          organizations,
+          canViewBillingEntities: canViewBillingEntities && billingEntities.length > 0,
+          billingEntities,
+          teams,
+        } satisfies Payload;
+      })
+    );
+  }
+
+  private fetchTeamsFromAllOrganizations(organizations: Organization[]): Observable<Team[]> {
+    // we can't use `getAllMemoized`, since we don't have the permission to list all teams in all namespaces at once.
+    // so we have to iterate over every organization we know, list them per namespace and collect/reduce them.
+    const allTeamsInAllNamespaces$: Observable<Team[]>[] = [];
+    organizations.forEach((org) => {
+      const teamsInNamespace = this.teamService
+        .getAllInNamespaceMemoized(org.metadata.name)
+        .pipe(take(1), catchError(defaultIfStatusCode<Team[]>([], [401, 403])));
+      allTeamsInAllNamespaces$.push(teamsInNamespace);
+    });
+    if (allTeamsInAllNamespaces$.length === 0) {
+      return of([]);
+    }
+
+    return from(allTeamsInAllNamespaces$).pipe(
+      combineLatestAll(),
+      switchMap((teamInAllNamespaces) =>
+        of(
+          teamInAllNamespaces.reduce((acc, curr) => {
+            acc.push(...curr);
+            return acc;
+          }, [])
+        )
+      )
+    );
+  }
+}
+
+interface Payload {
+  canViewOrganizations: boolean;
+  organizations: Organization[];
+  canViewBillingEntities: boolean;
+  billingEntities: BillingEntity[];
+  teams: Team[];
+}

--- a/src/app/invitations/invitation-form/invitation-form.component.html
+++ b/src/app/invitations/invitation-form/invitation-form.component.html
@@ -1,0 +1,141 @@
+<form (submit)="save()" [formGroup]="form" class="flex flex-column p-fluid">
+  <div class="">
+    <div class="field mb-4 col-12">
+      <label for="email" class="font-bold required" i18n>Email</label>
+      <input formControlName="email" id="email" pInputText type="email"/>
+    </div>
+    <div class="field mb-4 col-12">
+      <label for="note" i18n>Note</label>
+      <input formControlName="note" id="note" pInputText type="text"/>
+    </div>
+
+    <div class="mb-4 col-12" *ngIf="canInviteOrganization" id="organizationFormGroup">
+      <div class="hidden md:grid md:flex">
+        <label class="col-5" i18n>Organization</label>
+        <label class="col-1 text-center" i18n>Viewer</label>
+        <label class="col-1 text-center" i18n>Admin</label>
+        <label class="col-4" i18n>Team Memberships</label>
+      </div>
+      <div *ngFor="let control of this.form.controls.organizationTargets.controls; let i = index; let last = last"
+           [formGroup]="$any(control)" class="mb-3 grid formgrid">
+        <div class="field col-11 md:col-5">
+          <label i18n for="organization" class="md:hidden">Organization</label>
+          <p-dropdown
+            formControlName="organization"
+            optionLabel="displayName"
+            [options]="organizationOptions"
+            [styleClass]="'w-full'"
+            placeholder="Select Organization"
+            [filter]="true"
+            i18n-placeholder
+          />
+        </div>
+        <div class="field-checkbox col-1 md:justify-content-center min-w-min">
+          <label i18n for="isViewer" class="md:hidden">Viewer</label>
+          <p-checkbox formControlName="isViewer" [binary]="true" styleClass="m-1"/>
+        </div>
+        <div class="field-checkbox col-1 md:justify-content-center min-w-min">
+          <label i18n for="isAdmin" class="md:hidden">Admin</label>
+          <p-checkbox formControlName="isAdmin" [binary]="true" styleClass="m-1"/>
+        </div>
+
+        <div class="field col-4">
+          <label i18n for="teams" class="md:hidden">Team Memberships</label>
+          <p-multiSelect
+            formControlName="teams"
+            [options]="control.controls.selectableTeams.value ?? []"
+            optionLabel="metadata.name"
+            placeholder="Select Teams"
+            [styleClass]="'w-full'"
+            emptyMessage="No teams found in this organization"
+            i18n-placeholder
+            display="chip"
+          />
+        </div>
+        <div class="field col-11 md:col-1 md:max-w-min min-w-min">
+          <button
+            (click)="removeOrganization(i)"
+            *ngIf="!last; else noButton"
+            class="p-button"
+            i18n-title
+            pButton
+            pRipple
+            tabindex="1"
+            title="Remove"
+            type="button"
+          >
+            <fa-icon [icon]="faClose"/>
+            <span class="ml-1 md:hidden sm:white-space-nowrap" i18n>Remove Organization</span>
+          </button>
+        </div>
+        <ng-template #noButton>
+          <div class="ml-3 w-3rem"></div>
+        </ng-template>
+      </div>
+    </div>
+
+    <div class="mb-4 col-12" *ngIf="canInviteBilling" id="billingFormGroup">
+      <div class="hidden md:grid md:flex">
+        <label class="col-5" i18n>Billing</label>
+        <label class="col-1 text-center" i18n>Viewer</label>
+        <label class="col-1 text-center" i18n>Admin</label>
+      </div>
+      <div *ngFor="let control of this.form.controls.billingTargets.controls; let i = index; let last = last"
+           [formGroup]="$any(control)" class="mb-3 grid formgrid">
+        <div class="field col-11 md:col-5">
+          <label i18n for="billing" class="md:hidden">Billing</label>
+          <p-dropdown
+            formControlName="billing"
+            optionLabel="displayName"
+            [options]="billingOptions"
+            [styleClass]="'w-full'"
+            placeholder="Select Billing"
+            i18n
+          />
+        </div>
+        <div class="field-checkbox col-1 md:justify-content-center min-w-min">
+          <label i18n for="isViewer" class="md:hidden">Viewer</label>
+          <p-checkbox [formControl]="control.controls.isViewer" [binary]="true" styleClass="m-1" value="Viewer"/>
+
+        </div>
+        <div class="field-checkbox col-1 md:justify-content-center min-w-min">
+          <label i18n for="isAdmin" class="md:hidden">Admin</label>
+          <p-checkbox [formControl]="control.controls.isAdmin" [binary]="true" styleClass="m-1" value="Admin"/>
+        </div>
+        <div class="field-checkbox col-4">
+          <small *ngIf="control.controls.isViewer.hasError('atLeastOneRequired')" class="block p-error" i18n>
+            Select at least one role
+          </small>
+        </div>
+        <div class="field col-1 md:col-1 md:max-w-min min-w-min">
+          <button
+            (click)="removeBilling(i)"
+            *ngIf="!last; else noButton"
+            class="p-button"
+            i18n-title
+            pButton
+            pRipple
+            tabindex="1"
+            title="Remove"
+            type="button">
+            <fa-icon [icon]="faClose"/>
+            <span class="ml-1 md:hidden sm:white-space-nowrap" i18n>Remove Billing</span>
+          </button>
+        </div>
+        <ng-template #noButton>
+          <div class="ml-3 w-3rem"></div>
+        </ng-template>
+      </div>
+    </div>
+
+    <div class="col-12">
+      <button [disabled]="form.invalid" [loading]="(invitationService.loading$ | ngrxPush) ?? false" class="w-auto mt-3" pButton pRipple type="submit">
+        <fa-icon [icon]="faGift" class="pr-2" />
+        <span class="pr-2" i18n>Invite</span>
+      </button>
+      <small *ngIf="form.hasError('atLeastOneSelected')" class="block p-error mt-3" i18n>
+        Please select at least one element
+      </small>
+    </div>
+  </div>
+</form>

--- a/src/app/invitations/invitation-form/invitation-form.component.html
+++ b/src/app/invitations/invitation-form/invitation-form.component.html
@@ -44,7 +44,7 @@
           <p-multiSelect
             formControlName="teams"
             [options]="control.controls.selectableTeams.value ?? []"
-            optionLabel="metadata.name"
+            optionLabel="displayName"
             placeholder="Select Teams"
             [styleClass]="'w-full'"
             emptyMessage="No teams found in this organization"

--- a/src/app/invitations/invitation-form/invitation-form.component.html
+++ b/src/app/invitations/invitation-form/invitation-form.component.html
@@ -48,8 +48,9 @@
             placeholder="Select Teams"
             [styleClass]="'w-full'"
             emptyMessage="No teams found in this organization"
-            i18n-placeholder
             display="chip"
+            i18n-placeholder
+            i18n-emptyMessage
           />
         </div>
         <div class="field col-11 md:col-1 md:max-w-min min-w-min">

--- a/src/app/invitations/invitation-form/invitation-form.component.html
+++ b/src/app/invitations/invitation-form/invitation-form.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="field mb-4 col-12">
       <label for="note" i18n>Note</label>
-      <input formControlName="note" id="note" pInputText type="text"/>
+      <textarea pInputTextarea formControlName="note" id="note" [autoResize]="true" rows="3" cols="30"></textarea>
     </div>
 
     <div class="mb-4 col-12" *ngIf="canInviteOrganization" id="organizationFormGroup">

--- a/src/app/invitations/invitation-form/invitation-form.component.scss
+++ b/src/app/invitations/invitation-form/invitation-form.component.scss
@@ -1,0 +1,4 @@
+:host ::ng-deep .p-checkbox, :host ::ng-deep .p-checkbox-box {
+  width: 24px;
+  height: 24px;
+}

--- a/src/app/invitations/invitation-form/invitation-form.component.ts
+++ b/src/app/invitations/invitation-form/invitation-form.component.ts
@@ -1,0 +1,298 @@
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Organization } from '../../types/organization';
+import { BillingEntity } from '../../types/billing-entity';
+import { InvitationCollectionService } from '../../store/invitation-collection.service';
+import { MessageService } from 'primeng/api';
+import { Invitation, TargetRef } from '../../types/invitation';
+import { v4 as uuidv4 } from 'uuid';
+import { faClose, faGift } from '@fortawesome/free-solid-svg-icons';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { take } from 'rxjs';
+import { Team } from '../../types/team';
+import { RoleBindingPermissions } from '../../types/role-binding';
+import { ClusterRoleBindingPermissions } from '../../types/clusterrole-binding';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NavigationService } from '../../shared/navigation.service';
+
+@Component({
+  selector: 'app-invitation-form',
+  templateUrl: './invitation-form.component.html',
+  styleUrls: ['./invitation-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InvitationFormComponent implements OnInit {
+  @Input()
+  organizations!: Organization[];
+  @Input()
+  canInviteOrganization = false;
+
+  @Input()
+  billingEntities!: BillingEntity[];
+  @Input()
+  canInviteBilling = false;
+
+  @Input()
+  teams!: Team[];
+
+  faGift = faGift;
+  faClose = faClose;
+  form!: FormGroup<InvitationForm>;
+  organizationOptions: OrganizationOption[] = [];
+  billingOptions: BillingOption[] = [];
+
+  constructor(
+    public invitationService: InvitationCollectionService,
+    private messageService: MessageService,
+    private formBuilder: FormBuilder,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private navigationService: NavigationService
+  ) {}
+
+  ngOnInit(): void {
+    this.organizationOptions = this.organizations.map((organization) => {
+      return {
+        organization,
+        displayName: organization.spec.displayName
+          ? `${organization.spec.displayName} (${organization.metadata.name})`
+          : organization.metadata.name,
+      } satisfies OrganizationOption;
+    });
+    this.billingOptions = this.billingEntities.map((billingEntity) => {
+      return {
+        billingEntity,
+        displayName: billingEntity.spec.name
+          ? `${billingEntity.spec.name} (${billingEntity.metadata.name})`
+          : billingEntity.metadata.name,
+      } satisfies BillingOption;
+    });
+    this.form = this.formBuilder.nonNullable.group({
+      email: new FormControl('', { nonNullable: true, validators: [Validators.email, Validators.required] }),
+      note: new FormControl<string>('', { nonNullable: true }),
+      organizationTargets: new FormArray<FormGroup<OrganizationTarget>>([]),
+      billingTargets: new FormArray<FormGroup<BillingTarget>>([]),
+    } satisfies InvitationForm);
+    this.addEmptyOrganizationControl();
+    this.addEmptyBillingControl();
+  }
+
+  save(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    const invitation: Invitation = {
+      apiVersion: 'user.appuio.io/v1',
+      kind: 'Invitation',
+      metadata: {
+        name: uuidv4(),
+      },
+      spec: {
+        note: this.form.controls.note.value,
+        email: this.form.controls.email.value,
+        targetRefs: [],
+      },
+    };
+    const targetRefs: TargetRef[] = [];
+
+    this.form.controls.organizationTargets.controls.forEach((orgTarget) => {
+      const org = orgTarget.controls.organization.value?.organization;
+      if (!org) {
+        return;
+      }
+      targetRefs.push({
+        name: 'members',
+        kind: 'OrganizationMembers',
+        namespace: org.metadata.name,
+        apiGroup: 'appuio.io',
+      });
+      orgTarget.value.teams?.forEach((team) => {
+        targetRefs.push({
+          name: team.metadata.name,
+          namespace: team.metadata.namespace,
+          kind: team.kind,
+          apiGroup: 'appuio.io',
+        });
+      });
+      if (orgTarget.controls.isAdmin.value) {
+        targetRefs.push({
+          name: 'control-api:organization-admin',
+          namespace: org.metadata.name,
+          apiGroup: RoleBindingPermissions.group,
+          kind: 'RoleBinding',
+        });
+      }
+      if (orgTarget.controls.isViewer.value) {
+        targetRefs.push({
+          name: 'control-api:organization-viewer',
+          namespace: org.metadata.name,
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'RoleBinding',
+        });
+      }
+    });
+    this.form.controls.billingTargets.controls.forEach((beTarget) => {
+      const be = beTarget.controls.billing.value?.billingEntity;
+      if (!be) {
+        return;
+      }
+      if (beTarget.value.isViewer) {
+        targetRefs.push({
+          name: `billingentities-${be.metadata.name}-viewer`,
+          kind: 'ClusterRoleBinding',
+          apiGroup: ClusterRoleBindingPermissions.group,
+        });
+      }
+      if (beTarget.value.isAdmin) {
+        targetRefs.push({
+          name: `billingentities-${be.metadata.name}-admin`,
+          kind: 'ClusterRoleBinding',
+          apiGroup: ClusterRoleBindingPermissions.group,
+        });
+      }
+    });
+    if (targetRefs.length === 0) {
+      this.form.setErrors({ atLeastOneSelected: 'Select at least one option' });
+      return;
+    }
+
+    invitation.spec.targetRefs = targetRefs;
+    this.invitationService.add(invitation).subscribe({
+      next: () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Invitation successfully saved',
+        });
+        void this.router.navigate([this.navigationService.previousLocation('..')], { relativeTo: this.activatedRoute });
+      },
+      error: (err) => {
+        this.messageService.add({
+          severity: 'error',
+          summary: err.message,
+          sticky: true,
+        });
+      },
+    });
+  }
+
+  addEmptyOrganizationControl(): void {
+    const emptyFormControl = new FormGroup<OrganizationTarget>({
+      organization: new FormControl<OrganizationOption | undefined>(undefined, { nonNullable: true }),
+      isAdmin: new FormControl<boolean>(false, { nonNullable: true }),
+      isViewer: new FormControl<boolean>(false, { nonNullable: true }),
+      selectableTeams: new FormControl<Team[] | undefined>(undefined, { nonNullable: true }),
+      teams: new FormControl<Team[] | undefined>(undefined, { nonNullable: true }),
+    });
+
+    emptyFormControl.controls.organization.valueChanges.pipe(take(1)).subscribe(() => {
+      this.addEmptyOrganizationControl();
+    });
+    emptyFormControl.controls.teams.disable();
+    emptyFormControl.controls.isViewer.disable();
+    emptyFormControl.controls.isAdmin.disable();
+    emptyFormControl.controls.organization.valueChanges.subscribe((org) => {
+      emptyFormControl.controls.teams.reset();
+      if (org) {
+        emptyFormControl.controls.selectableTeams.setValue(
+          this.teams.filter((team) => team.metadata.namespace === org?.organization.metadata.name)
+        );
+        emptyFormControl.controls.teams.enable();
+        emptyFormControl.controls.isAdmin.enable();
+        emptyFormControl.controls.isViewer.enable();
+      } else {
+        emptyFormControl.controls.selectableTeams.reset();
+      }
+    });
+
+    this.form.controls.organizationTargets.push(emptyFormControl);
+  }
+
+  addEmptyBillingControl(): void {
+    const emptyFormControl = new FormGroup<BillingTarget>({
+      billing: new FormControl<BillingOption | undefined>(undefined, { nonNullable: true }),
+      isAdmin: new FormControl<boolean>(false, { nonNullable: true }),
+      isViewer: new FormControl<boolean>(false, { nonNullable: true }),
+    });
+    emptyFormControl.controls.isAdmin.setValidators(atLeastOneChecked(emptyFormControl.controls.isViewer));
+    emptyFormControl.controls.isViewer.setValidators(atLeastOneChecked(emptyFormControl.controls.isAdmin));
+    [emptyFormControl.controls.isViewer, emptyFormControl.controls.isAdmin].forEach((control) => {
+      control.disable();
+    });
+    emptyFormControl.controls.billing.valueChanges.subscribe((be) => {
+      [emptyFormControl.controls.isViewer, emptyFormControl.controls.isAdmin].forEach((control) => {
+        if (be) {
+          control.enable();
+        }
+      });
+    });
+    emptyFormControl.controls.billing.valueChanges.pipe(take(1)).subscribe(() => {
+      this.addEmptyBillingControl();
+    });
+    this.form.controls.billingTargets.push(emptyFormControl);
+  }
+
+  removeOrganization(index: number): void {
+    this.form.controls.organizationTargets.removeAt(index);
+  }
+
+  removeBilling(index: number): void {
+    this.form.controls.billingTargets.removeAt(index);
+  }
+}
+
+interface InvitationForm {
+  note: FormControl<string>;
+  email: FormControl<string>;
+  organizationTargets: FormArray<FormGroup<OrganizationTarget>>;
+  billingTargets: FormArray<FormGroup<BillingTarget>>;
+}
+
+interface OrganizationTarget {
+  organization: FormControl<OrganizationOption | undefined>;
+  isViewer: FormControl<boolean>;
+  isAdmin: FormControl<boolean>;
+  teams: FormControl<Team[] | undefined>;
+  selectableTeams: FormControl<Team[] | undefined>;
+}
+
+interface OrganizationOption {
+  organization: Organization;
+  displayName: string;
+}
+
+interface BillingOption {
+  billingEntity: BillingEntity;
+  displayName: string;
+}
+
+interface BillingTarget {
+  billing: FormControl<BillingOption | undefined>;
+  isViewer: FormControl<boolean>;
+  isAdmin: FormControl<boolean>;
+}
+
+function atLeastOneChecked<T extends AbstractControl<boolean, boolean>>(
+  other: FormControl<boolean>
+): (control: T) => ValidationErrors | null {
+  return (control): ValidationErrors | null => {
+    if (!control.value && !other.value) {
+      const err = {
+        atLeastOneRequired: 'at least one is required',
+      };
+      other.setErrors(err);
+      other.markAsDirty();
+      return err;
+    }
+    if (control.value) {
+      other.setErrors(null);
+    }
+    return null;
+  };
+}

--- a/src/app/invitations/invitation-form/invitation-form.component.ts
+++ b/src/app/invitations/invitation-form/invitation-form.component.ts
@@ -6,15 +6,7 @@ import { MessageService } from 'primeng/api';
 import { Invitation, TargetRef } from '../../types/invitation';
 import { v4 as uuidv4 } from 'uuid';
 import { faClose, faGift } from '@fortawesome/free-solid-svg-icons';
-import {
-  AbstractControl,
-  FormArray,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ValidationErrors,
-  Validators,
-} from '@angular/forms';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { take } from 'rxjs';
 import { Team } from '../../types/team';
 import { RoleBindingPermissions } from '../../types/role-binding';
@@ -22,6 +14,15 @@ import { ClusterRoleBindingPermissions } from '../../types/clusterrole-binding';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NavigationService } from '../../shared/navigation.service';
 import { KubeObject } from '../../types/entity';
+import {
+  BillingOption,
+  BillingTarget,
+  InvitationForm,
+  OrganizationOption,
+  OrganizationTarget,
+  TeamOption,
+} from './invitation-form.types';
+import { atLeastOneChecked } from './invitation-form.util';
 
 @Component({
   selector: 'app-invitation-form',
@@ -256,59 +257,4 @@ export class InvitationFormComponent implements OnInit {
     }
     return entity.metadata.name;
   }
-}
-
-interface InvitationForm {
-  note: FormControl<string>;
-  email: FormControl<string>;
-  organizationTargets: FormArray<FormGroup<OrganizationTarget>>;
-  billingTargets: FormArray<FormGroup<BillingTarget>>;
-}
-
-interface OrganizationTarget {
-  organization: FormControl<OrganizationOption | undefined>;
-  isViewer: FormControl<boolean>;
-  isAdmin: FormControl<boolean>;
-  teams: FormControl<TeamOption[] | undefined>;
-  selectableTeams: FormControl<TeamOption[] | undefined>;
-}
-
-interface OrganizationOption {
-  organization: Organization;
-  displayName: string;
-}
-
-interface BillingOption {
-  billingEntity: BillingEntity;
-  displayName: string;
-}
-
-interface TeamOption {
-  team: Team;
-  displayName: string;
-}
-
-interface BillingTarget {
-  billing: FormControl<BillingOption | undefined>;
-  isViewer: FormControl<boolean>;
-  isAdmin: FormControl<boolean>;
-}
-
-function atLeastOneChecked<T extends AbstractControl<boolean, boolean>>(
-  other: FormControl<boolean>
-): (control: T) => ValidationErrors | null {
-  return (control): ValidationErrors | null => {
-    if (!control.value && !other.value) {
-      const err = {
-        atLeastOneRequired: 'at least one is required',
-      };
-      other.setErrors(err);
-      other.markAsDirty();
-      return err;
-    }
-    if (control.value) {
-      other.setErrors(null);
-    }
-    return null;
-  };
 }

--- a/src/app/invitations/invitation-form/invitation-form.types.ts
+++ b/src/app/invitations/invitation-form/invitation-form.types.ts
@@ -1,0 +1,40 @@
+import { Organization } from '../../types/organization';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import { BillingEntity } from '../../types/billing-entity';
+import { Team } from '../../types/team';
+
+export interface InvitationForm {
+  note: FormControl<string>;
+  email: FormControl<string>;
+  organizationTargets: FormArray<FormGroup<OrganizationTarget>>;
+  billingTargets: FormArray<FormGroup<BillingTarget>>;
+}
+
+export interface OrganizationTarget {
+  organization: FormControl<OrganizationOption | undefined>;
+  isViewer: FormControl<boolean>;
+  isAdmin: FormControl<boolean>;
+  teams: FormControl<TeamOption[] | undefined>;
+  selectableTeams: FormControl<TeamOption[] | undefined>;
+}
+
+export interface OrganizationOption {
+  organization: Organization;
+  displayName: string;
+}
+
+export interface BillingOption {
+  billingEntity: BillingEntity;
+  displayName: string;
+}
+
+export interface TeamOption {
+  team: Team;
+  displayName: string;
+}
+
+export interface BillingTarget {
+  billing: FormControl<BillingOption | undefined>;
+  isViewer: FormControl<boolean>;
+  isAdmin: FormControl<boolean>;
+}

--- a/src/app/invitations/invitation-form/invitation-form.util.ts
+++ b/src/app/invitations/invitation-form/invitation-form.util.ts
@@ -1,0 +1,20 @@
+import { AbstractControl, FormControl, ValidationErrors } from '@angular/forms';
+
+export function atLeastOneChecked<T extends AbstractControl<boolean, boolean>>(
+  other: FormControl<boolean>
+): (control: T) => ValidationErrors | null {
+  return (control): ValidationErrors | null => {
+    if (!control.value && !other.value) {
+      const err = {
+        atLeastOneRequired: 'at least one is required',
+      };
+      other.setErrors(err);
+      other.markAsDirty();
+      return err;
+    }
+    if (control.value) {
+      other.setErrors(null);
+    }
+    return null;
+  };
+}

--- a/src/app/invitations/invitations-routing.module.ts
+++ b/src/app/invitations/invitations-routing.module.ts
@@ -4,6 +4,7 @@ import { KubernetesPermissionGuard } from '../kubernetes-permission.guard';
 import { InvitationsComponent } from './invitations.component';
 import { InvitationPermissions } from '../types/invitation';
 import { InvitationViewComponent } from './invitation-view/invitation-view.component';
+import { InvitationEditComponent } from './invitation-edit/invitation-edit.component';
 
 const routes: Routes = [
   {
@@ -12,6 +13,14 @@ const routes: Routes = [
     canActivate: [KubernetesPermissionGuard],
     data: {
       requiredKubernetesPermissions: [{ ...InvitationPermissions, verb: 'list' }],
+    },
+  },
+  {
+    path: 'create',
+    component: InvitationEditComponent,
+    canActivate: [KubernetesPermissionGuard],
+    data: {
+      requiredKubernetesPermissions: [{ ...InvitationPermissions, verb: 'create' }],
     },
   },
   {

--- a/src/app/invitations/invitations.component.html
+++ b/src/app/invitations/invitations.component.html
@@ -1,5 +1,15 @@
 <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
   <h1 class="pt-0 mt-0 mb-0" i18n id="title">Invitations</h1>
+
+  <div class="flex flex-wrap gap-2">
+    <div>
+      <a class="mr-2 w-full white-space-nowrap no-underline" id="createInvitationButton" [routerLink]="['create']" pButton pRipple>
+        <fa-icon [icon]="faGift" class="mr-2"></fa-icon>
+        <span i18n>Invite User</span>
+      </a>
+    </div>
+
+  </div>
 </div>
 
 <ng-container *ngrxLet="payload$ as payload; suspenseTpl: loading; error as err">

--- a/src/app/invitations/invitations.component.html
+++ b/src/app/invitations/invitations.component.html
@@ -1,20 +1,29 @@
-<div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
-  <h1 class="pt-0 mt-0 mb-0" i18n id="title">Invitations</h1>
-
-  <div class="flex flex-wrap gap-2">
-    <div>
-      <a class="mr-2 w-full white-space-nowrap no-underline" id="createInvitationButton" [routerLink]="['create']" pButton pRipple>
-        <fa-icon [icon]="faGift" class="mr-2"></fa-icon>
-        <span i18n>Invite User</span>
-      </a>
-    </div>
-
-  </div>
-</div>
-
 <ng-container *ngrxLet="payload$ as payload; suspenseTpl: loading; error as err">
   <ng-container *ngIf="payload">
-      <app-invitation-detail *ngFor="let invitation of payload.invitations" [invitation]="invitation" [showCloseButton]="false" />
+    <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
+      <h1 class="pt-0 mt-0 mb-0" i18n id="title">Invitations</h1>
+
+      <div class="flex flex-wrap gap-2">
+        <div>
+          <a
+            *ngIf="payload.canInvite"
+            class="mr-2 w-full white-space-nowrap no-underline"
+            id="createInvitationButton"
+            [routerLink]="['create']"
+            pButton pRipple
+          >
+            <fa-icon [icon]="faGift" class="mr-2"/>
+            <span i18n>Invite User</span>
+          </a>
+        </div>
+
+      </div>
+    </div>
+    <app-invitation-detail
+      *ngFor="let invitation of payload.invitations"
+      [invitation]="invitation"
+      [showCloseButton]="false"
+    />
   </ng-container>
 
   <ng-container *ngIf="payload?.invitations?.length === 0 && !err">

--- a/src/app/invitations/invitations.component.ts
+++ b/src/app/invitations/invitations.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { InvitationCollectionService } from '../store/invitation-collection.service';
 import { Invitation } from '../types/invitation';
 import { map, Observable } from 'rxjs';
-import { faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
+import { faGift, faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-invitations',
@@ -15,6 +15,7 @@ export class InvitationsComponent implements OnInit {
 
   faWarning = faWarning;
   faInfo = faInfo;
+  faGift = faGift;
 
   constructor(private invitationService: InvitationCollectionService) {}
 

--- a/src/app/invitations/invitations.component.ts
+++ b/src/app/invitations/invitations.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { InvitationCollectionService } from '../store/invitation-collection.service';
 import { Invitation } from '../types/invitation';
-import { map, Observable } from 'rxjs';
+import { combineLatestWith, map, Observable } from 'rxjs';
 import { faGift, faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
@@ -21,9 +21,11 @@ export class InvitationsComponent implements OnInit {
 
   ngOnInit(): void {
     this.payload$ = this.invitationService.getAllMemoized().pipe(
-      map((invitations) => {
+      combineLatestWith(this.invitationService.canInviteUsers$),
+      map(([invitations, canInvite]) => {
         return {
           invitations,
+          canInvite,
         } satisfies Payload;
       })
     );
@@ -32,4 +34,5 @@ export class InvitationsComponent implements OnInit {
 
 interface Payload {
   invitations: Invitation[];
+  canInvite: boolean;
 }

--- a/src/app/invitations/invitations.module.ts
+++ b/src/app/invitations/invitations.module.ts
@@ -4,9 +4,17 @@ import { InvitationsComponent } from './invitations.component';
 import { InvitationsRoutingModule } from './invitations-routing.module';
 import { InvitationDetailComponent } from './invitation-detail/invitation-detail.component';
 import { InvitationViewComponent } from './invitation-view/invitation-view.component';
+import { InvitationFormComponent } from './invitation-form/invitation-form.component';
+import { InvitationEditComponent } from './invitation-edit/invitation-edit.component';
 
 @NgModule({
-  declarations: [InvitationsComponent, InvitationDetailComponent, InvitationViewComponent],
+  declarations: [
+    InvitationsComponent,
+    InvitationDetailComponent,
+    InvitationViewComponent,
+    InvitationFormComponent,
+    InvitationEditComponent,
+  ],
   imports: [SharedModule, InvitationsRoutingModule],
 })
 export default class InvitationsModule {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import { MultiSelectModule } from 'primeng/multiselect';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { BackLinkDirective } from './back-link.directive';
 import { TableModule } from 'primeng/table';
+import { InputTextareaModule } from 'primeng/inputtextarea';
 
 @NgModule({
   declarations: [BackLinkDirective],
@@ -51,6 +52,7 @@ import { TableModule } from 'primeng/table';
     ProgressSpinnerModule,
     BackLinkDirective,
     TableModule,
+    InputTextareaModule,
   ],
 })
 export class SharedModule {}

--- a/src/app/store/billingentity-collection.service.ts
+++ b/src/app/store/billingentity-collection.service.ts
@@ -3,20 +3,28 @@ import { KubernetesCollectionService } from './kubernetes-collection.service';
 import { billingEntityEntityKey } from './entity-metadata-map';
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data';
 import { BillingEntity, BillingEntityPermissions } from '../types/billing-entity';
-import { Observable } from 'rxjs';
-import { Verb } from './app.reducer';
 import { SelfSubjectAccessReviewCollectionService } from './ssar-collection.service';
+import { Verb } from './app.reducer';
+import { Observable } from 'rxjs';
 import { ClusterRoleBindingPermissions } from '../types/clusterrole-binding';
 
 @Injectable({
   providedIn: 'root',
 })
 export class BillingEntityCollectionService extends KubernetesCollectionService<BillingEntity> {
+  canViewBillingEntities$: Observable<boolean>;
+
   constructor(
     elementsFactory: EntityCollectionServiceElementsFactory,
     private permissionService: SelfSubjectAccessReviewCollectionService
   ) {
     super(billingEntityEntityKey, elementsFactory);
+
+    this.canViewBillingEntities$ = permissionService.isAllowed(
+      BillingEntityPermissions.group,
+      BillingEntityPermissions.resource,
+      Verb.List
+    );
   }
 
   canViewBilling(name: string): Observable<boolean> {

--- a/src/app/store/invitation-collection.service.ts
+++ b/src/app/store/invitation-collection.service.ts
@@ -2,17 +2,30 @@ import { Injectable } from '@angular/core';
 import { KubernetesCollectionService } from './kubernetes-collection.service';
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data';
 import { invitationEntityKey } from './entity-metadata-map';
-import { Invitation } from '../types/invitation';
+import { Invitation, InvitationPermissions } from '../types/invitation';
 import { Observable, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { apiPrefix } from './kubernetes-url-generator.service';
+import { SelfSubjectAccessReviewCollectionService } from './ssar-collection.service';
+import { Verb } from './app.reducer';
 
 @Injectable({
   providedIn: 'root',
 })
 export class InvitationCollectionService extends KubernetesCollectionService<Invitation> {
-  constructor(elementsFactory: EntityCollectionServiceElementsFactory, private http: HttpClient) {
+  canInviteUsers$: Observable<boolean>;
+
+  constructor(
+    elementsFactory: EntityCollectionServiceElementsFactory,
+    private http: HttpClient,
+    permissionService: SelfSubjectAccessReviewCollectionService
+  ) {
     super(invitationEntityKey, elementsFactory);
+    this.canInviteUsers$ = permissionService.isAllowed(
+      InvitationPermissions.group,
+      InvitationPermissions.resource,
+      Verb.Create
+    );
   }
 
   redeemInvitation(invitation: Invitation): Observable<Invitation> {

--- a/src/app/store/invitation-collection.service.ts
+++ b/src/app/store/invitation-collection.service.ts
@@ -27,7 +27,7 @@ export class InvitationCollectionService extends KubernetesCollectionService<Inv
       )
       .pipe(
         tap(() => {
-          this.updateOneInCache(invitation);
+          this.upsertOneInCache(invitation);
         })
       );
   }

--- a/src/app/store/organization-collection.service.ts
+++ b/src/app/store/organization-collection.service.ts
@@ -15,6 +15,7 @@ import { metadataNameFilter } from './entity-filter';
 export class OrganizationCollectionService extends KubernetesCollectionService<Organization> {
   isEmptyAndLoaded$: Observable<boolean>;
   canAddOrganizations$: Observable<boolean>;
+  canViewOrganizations$: Observable<boolean>;
   selectedOrganization$: Observable<Organization>;
 
   constructor(
@@ -33,6 +34,12 @@ export class OrganizationCollectionService extends KubernetesCollectionService<O
       permissionService.isAllowed(OrganizationPermissions.group, OrganizationPermissions.resource, Verb.Create),
       permissionService.isAllowed(BillingEntityPermissions.group, BillingEntityPermissions.resource, Verb.List),
     ]).pipe(map(([orgCreateAllowed, beListAllowed]) => orgCreateAllowed && beListAllowed));
+
+    this.canViewOrganizations$ = permissionService.isAllowed(
+      OrganizationPermissions.group,
+      OrganizationPermissions.resource,
+      Verb.List
+    );
 
     this.selectedOrganization$ = this.filteredEntities$.pipe(
       filter((org) => org.length > 0),

--- a/src/app/teams/team-edit/team-edit.component.ts
+++ b/src/app/teams/team-edit/team-edit.component.ts
@@ -47,7 +47,7 @@ export class TeamEditComponent implements OnInit {
     ).pipe(
       tap((team) => {
         this.form = this.formBuilder.nonNullable.group({
-          displayName: [team.spec.displayName],
+          displayName: [team.spec.displayName ?? ''],
           name: [
             team.metadata.name,
             [

--- a/src/app/types/team.ts
+++ b/src/app/types/team.ts
@@ -11,7 +11,7 @@ export interface Team extends KubeObject {
     [key: string]: unknown;
   };
   spec: {
-    displayName: string;
+    displayName?: string;
     userRefs: UserRef[];
   };
 }


### PR DESCRIPTION
## Summary

Part of #460 

This PR adds a new form under `/invitations/create`, in which the user can invite another user to one or more entities as described in https://kb.vshn.ch/appuio-cloud/references/architecture/control-api-invitation.html.

Permissions
Some Kubernetes permissions are required: `create` on `Invitation`, `list` on either `billingentity` or `organization`.
Additionally, it will show an error if no billing entity and no organization could be retrieved, as that would be useless since you can't invite to entities you aren't yourself part of.
If one list is empty but not the other, the mask will be shown, but the user can only select entities from the list which have at least one element.

Note: Currently, the [control-api user role](https://github.com/appuio/control-api/blob/e25a4f9bbe96eb04203f2e97a594ee21abe5af82/config/user-rbac/basic-user-role.yml#L27) doesn't yet have `create` permissions, so this feature is only available for VSHNeers.



## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
