### PR TITLE
Guide first-time-users through initial setup

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   videosFolder: 'cypress/videos',
   screenshotsFolder: 'cypress/screenshots',
   fixturesFolder: 'cypress/fixtures',
-  retries: 2,
+  retries: process.env['CI'] ? 2 : 0,
   e2e: {
     baseUrl: 'http://localhost:4200',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -25,12 +25,12 @@ describe('Test billing entity list', () => {
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
   });
 
-  it('empty list should redirect to new', () => {
+  it('empty list', () => {
     setBillingEntities(cy);
     cy.visit('/billingentities');
-    cy.get('#title').should('contain.text', 'New Billing');
-
-    cy.url().should('contain', 'billingentities/$new?edit=y');
+    cy.get('#billingentities-title').should('contain.text', 'Billing');
+    cy.get('#addButton').should('contain.text', 'Add new Billing');
+    cy.get('#no-billingentity-message').should('contain.text', 'No billing address available.');
   });
 
   it('request failed', () => {
@@ -91,7 +91,7 @@ describe('no permissions', () => {
     cy.visit('/billingentities');
     cy.get('h1').should('contain.text', 'Billing');
     cy.get('addButton').should('not.exist');
-    cy.get('#no-billingentity-message').should('contain.text', 'No billing entities available.');
+    cy.get('#no-billingentity-message').should('contain.text', 'No billing address available.');
   });
 
   it('no edit permission', () => {

--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -25,12 +25,12 @@ describe('Test billing entity list', () => {
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
   });
 
-  it('empty list', () => {
+  it('empty list should redirect to new', () => {
     setBillingEntities(cy);
     cy.visit('/billingentities');
-    cy.get('#billingentities-title').should('contain.text', 'Billing');
-    cy.get('#addButton').should('contain.text', 'Add new Billing');
-    cy.get('#no-billingentity-message').should('contain.text', 'No billing entities available.');
+    cy.get('#title').should('contain.text', 'New Billing');
+
+    cy.url().should('contain', 'billingentities/$new?edit=y');
   });
 
   it('request failed', () => {
@@ -91,6 +91,7 @@ describe('no permissions', () => {
     cy.visit('/billingentities');
     cy.get('h1').should('contain.text', 'Billing');
     cy.get('addButton').should('not.exist');
+    cy.get('#no-billingentity-message').should('contain.text', 'No billing entities available.');
   });
 
   it('no edit permission', () => {

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -162,7 +162,7 @@ describe('Test billing entity form elements', () => {
   });
 
   it('should cancel editing', () => {
-    setBillingEntities(cy);
+    setBillingEntities(cy, billingEntityNxt); // give at least 1 item to avoid redirect back to form.
 
     ['.p-button-secondary', 'a[appbacklink]'].forEach((cancelSelector) => {
       cy.visit('/billingentities/$new?edit=y');
@@ -171,7 +171,7 @@ describe('Test billing entity form elements', () => {
       cy.get(cancelSelector).click();
       cy.get('app-billingentity-form').should('not.exist');
 
-      cy.get('p-messages').should('contain.text', 'No billing entities available');
+      cy.get('.text-3xl').should('have.length', 1);
     });
   });
 });

--- a/cypress/e2e/first-time-login.cy.ts
+++ b/cypress/e2e/first-time-login.cy.ts
@@ -1,11 +1,171 @@
 import { createUser } from '../fixtures/user';
-import { organizationListNxtVshn, setOrganization } from '../fixtures/organization';
+import { organizationListNxtVshn, organizationNxt, setOrganization } from '../fixtures/organization';
 import { OrganizationPermissions } from '../../src/app/types/organization';
-import { createOrganizationMembers } from '../fixtures/organization-members';
 import { OrganizationMembersPermissions } from '../../src/app/types/organization-members';
 import { InvitationPermissions } from '../../src/app/types/invitation';
+import { BillingEntityPermissions } from '../../src/app/types/billing-entity';
+import { billingEntityNxt, setBillingEntities } from '../fixtures/billingentities';
+import { createInvitation } from '../fixtures/invitations';
+import { createOrganizationMembers } from '../fixtures/organization-members';
 
 describe('Test First Time Login', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.removeItem('hideFirstTimeLoginDialog');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // we assume we don't have the user object yet.
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      statusCode: 403,
+    });
+  });
+
+  it('join organization if not part of organization', () => {
+    cy.setPermission(
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions },
+      { verb: 'create', ...BillingEntityPermissions }
+    );
+    setOrganization(cy);
+    setBillingEntities(cy);
+    cy.visit('/');
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#setDefaultOrganizationDialogButton').should('not.exist');
+    cy.get('#addBillingDialogButton').should('exist');
+    cy.get('#addOrganizationDialogButton').should('not.exist');
+    cy.get('#joinOrganizationDialogButton').click();
+    cy.get('.p-dialog-header').should('contain.text', 'Join Organization');
+  });
+
+  it('join organization if not part of organization and no billing access', () => {
+    cy.setPermission({ verb: 'list', ...OrganizationPermissions });
+    setOrganization(cy);
+    cy.visit('/');
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#setDefaultOrganizationDialogButton').should('not.exist');
+    cy.get('#addBillingDialogButton').should('not.exist');
+    cy.get('#addOrganizationDialogButton').should('not.exist');
+    cy.get('#joinOrganizationDialogButton').click();
+    cy.get('.p-dialog-header').should('contain.text', 'Join Organization');
+  });
+
+  it('add organization if not part of organization but part of billing', () => {
+    cy.setPermission(
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions },
+      { verb: 'create', ...BillingEntityPermissions }
+    );
+    setBillingEntities(cy, billingEntityNxt);
+    setOrganization(cy);
+    cy.visit('/');
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#joinOrganizationDialogButton').should('exist');
+    cy.get('#setDefaultOrganizationDialogButton').should('not.exist');
+    cy.get('#addBillingDialogButton').should('not.exist');
+    cy.get('#addOrganizationDialogButton').click();
+    cy.get('.text-3xl > .ng-star-inserted').should('contain.text', 'New Organization');
+    cy.get('.p-dialog-header').should('not.exist');
+  });
+
+  it('add billing if not part of organization', () => {
+    cy.setPermission(
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions },
+      { verb: 'create', ...BillingEntityPermissions }
+    );
+    setBillingEntities(cy);
+    setOrganization(cy);
+    cy.visit('/');
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#joinOrganizationDialogButton').should('exist');
+    cy.get('#setDefaultOrganizationDialogButton').should('not.exist');
+    cy.get('#addOrganizationDialogButton').should('not.exist');
+    cy.get('#addBillingDialogButton').click();
+    cy.get('.text-3xl > .ng-star-inserted').should('contain.text', 'New Billing');
+    cy.get('.p-dialog-header').should('not.exist');
+  });
+
+  it('show dialog with button to set default org because user has no default organization yet', () => {
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig' }),
+    }).as('getUser');
+    cy.setPermission(
+      { verb: 'list', ...OrganizationPermissions },
+      { verb: 'list', ...BillingEntityPermissions },
+      { verb: 'create', ...BillingEntityPermissions }
+    );
+    setOrganization(cy, organizationNxt);
+    setBillingEntities(cy, billingEntityNxt);
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
+      body: createOrganizationMembers({
+        namespace: 'nxt',
+        userRefs: [{ name: 'mig' }],
+      }),
+    });
+
+    cy.visit('/');
+    cy.wait('@getUser');
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#joinOrganizationDialogButton').should('not.exist');
+    cy.get('#addBillingDialogButton').should('not.exist');
+    cy.get('#setDefaultOrganizationDialogButton').click();
+
+    cy.get('.p-dialog-header').should('not.exist');
+    cy.get('.text-3xl', { timeout: 1000000 }).should('contain.text', 'User');
+  });
+});
+
+describe('hide dialog', () => {
+  beforeEach(() => {
+    cy.setupAuth();
+    window.localStorage.removeItem('hideFirstTimeLoginDialog');
+    cy.disableCookieBanner();
+  });
+  beforeEach(() => {
+    // needed for initial getUser request
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
+      body: createUser({ username: 'mig' }),
+    });
+  });
+
+  it('do not show dialog again', () => {
+    cy.setPermission({ verb: 'list', ...OrganizationPermissions });
+    setOrganization(cy, organizationNxt);
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
+      body: createOrganizationMembers({
+        namespace: 'nxt',
+        userRefs: [{ name: 'mig' }, { name: 'miw' }],
+      }),
+    });
+
+    cy.visit('/');
+
+    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('#joinOrganizationDialogButton').should('not.exist');
+
+    cy.get('label[for=hideFirstTimeLoginDialogCheckbox]').click();
+    cy.get('#setDefaultOrganizationDialogButton').click();
+
+    cy.get('.text-3xl').should('contain.text', 'User');
+
+    cy.get('app-navbar-item').contains('Organizations').click();
+    cy.get('#organizations-title').should('contain.text', 'Organizations');
+    cy.get('.p-dialog-header').should('not.exist');
+    cy.getAllLocalStorage().then((result) => {
+      const expected = {
+        'http://localhost:4200': {
+          hideFirstTimeLoginDialog: 'true',
+        },
+      };
+      console.debug('expected', expected);
+      console.debug('result', result);
+      expect(result).to.deep.eq(expected);
+    });
+  });
+});
+
+describe('skip dialog', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.removeItem('hideFirstTimeLoginDialog');
@@ -18,43 +178,11 @@ describe('Test First Time Login', () => {
     });
   });
 
-  it('join organization', () => {
+  it('do not show dialog if member of organization', () => {
     cy.setPermission({ verb: 'list', ...OrganizationPermissions });
-    setOrganization(cy);
-    cy.visit('/');
-    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
-    cy.get('#joinOrganizationDialogButton').click();
-    cy.get('.p-dialog-header').should('contain.text', 'Join Organization');
-  });
-  // some requirements may change, see https://github.com/appuio/cloud-portal/issues/438, skipping until it's clear.
-  it.skip('add organization', () => {
-    cy.setPermission({ verb: 'list', ...OrganizationPermissions });
-    setOrganization(cy);
-    cy.visit('/');
-    cy.get('.p-dialog-header').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
-    cy.get('#addOrganizationDialogButton').click();
-    cy.get('.text-3xl > .ng-star-inserted').should('contain.text', 'New Organization');
-  });
-
-  it('do not show dialog', () => {
-    cy.setPermission(
-      { verb: 'list', resource: 'organizationmembers', group: 'rbac.appuio.io' },
-      { verb: 'list', ...OrganizationPermissions }
-    );
     setOrganization(cy, ...organizationListNxtVshn.items);
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'nxt',
-        userRefs: [{ name: 'mig' }, { name: 'miw' }],
-      }),
-    });
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/vshn/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'vshn',
-        userRefs: [{ name: 'tobru' }, { name: 'corvus' }],
-      }),
-    });
     cy.visit('/');
+    cy.wait('@organizationList');
     cy.get('.p-dialog-header').should('not.exist');
   });
 
@@ -65,76 +193,11 @@ describe('Test First Time Login', () => {
       { verb: 'list', ...InvitationPermissions }
     );
     setOrganization(cy);
+    cy.intercept('GET', 'appuio-api/apis/user.appuio.io/v1/invitations/uuid', {
+      body: createInvitation({}),
+    });
     cy.visit('/invitations/uuid');
     cy.get('#title').should('contain.text', 'Invitation');
     cy.get('.p-dialog-header').should('not.exist');
-  });
-
-  // some requirements may change, see https://github.com/appuio/cloud-portal/issues/438, skipping until it's clear.
-  it.skip('do not show dialog again', () => {
-    cy.setPermission({ verb: 'list', ...OrganizationPermissions });
-    setOrganization(cy);
-    cy.visit('/');
-    cy.get('#joinOrganizationDialogButton').should('exist');
-    cy.get('#addOrganizationDialogButton').should('exist');
-
-    cy.get('label[for=hideFirstTimeLoginDialogCheckbox]').click();
-    cy.get('#addOrganizationDialogButton').click();
-    cy.get('.text-3xl > .ng-star-inserted').should('contain.text', 'New Organization');
-    cy.visit('/teams');
-    cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get('.p-dialog-header').should('not.exist');
-  });
-
-  it('show dialog because no organization contains current username', () => {
-    cy.setPermission(
-      { verb: 'list', resource: 'organizationmembers', group: 'rbac.appuio.io' },
-      { verb: 'list', resource: 'organizations', group: 'rbac.appuio.io' }
-    );
-    setOrganization(cy, ...organizationListNxtVshn.items);
-
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'nxt',
-        userRefs: [{ name: 'miw' }],
-      }),
-    });
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/vshn/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'vshn',
-        userRefs: [{ name: 'tobru' }, { name: 'corvus' }],
-      }),
-    });
-    cy.visit('/');
-    cy.get('#joinOrganizationDialogButton').should('exist');
-    cy.get('#addOrganizationDialogButton').should('exist');
-    cy.get('#setDefaultOrganizationDialogButton').should('not.exist');
-  });
-
-  it('show dialog with button to set default org because user has no default organization yet', () => {
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
-      body: createUser({ username: 'mig' }),
-    }).as('getUser');
-    cy.setPermission(
-      { verb: 'list', resource: 'organizationmembers', group: 'rbac.appuio.io' },
-      { verb: 'list', resource: 'organizations', group: 'rbac.appuio.io' }
-    );
-    setOrganization(cy, ...organizationListNxtVshn.items);
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/nxt/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'nxt',
-        userRefs: [{ name: 'mig' }],
-      }),
-    });
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/namespaces/vshn/organizationmembers/members', {
-      body: createOrganizationMembers({
-        namespace: 'vshn',
-        userRefs: [{ name: 'tobru' }, { name: 'corvus' }],
-      }),
-    });
-    cy.visit('/');
-    cy.get('#joinOrganizationDialogButton').should('not.exist');
-    cy.get('#addOrganizationDialogButton').should('not.exist');
-    cy.get('#setDefaultOrganizationDialogButton').should('exist');
   });
 });

--- a/cypress/e2e/organizations.cy.ts
+++ b/cypress/e2e/organizations.cy.ts
@@ -37,26 +37,12 @@ describe('Test organization list', () => {
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
   });
 
-  it('empty list without billing list permission', () => {
+  it('empty list', () => {
     setOrganization(cy);
     cy.visit('/organizations');
     cy.wait('@organizationList');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get('#no-organization-message').should('contain.text', 'No organizations available.');
-  });
-
-  it('empty list with billing list permission', () => {
-    cy.setPermission(
-      { verb: 'list', ...OrganizationPermissions },
-      { verb: 'create', ...OrganizationPermissions },
-      { verb: 'list', ...BillingEntityPermissions }
-    );
-    setOrganization(cy);
-    setBillingEntities(cy);
-    cy.visit('/organizations');
-    cy.wait('@organizationList');
-    cy.get('#title').should('contain.text', 'New Organization');
-    cy.url().should('contain', '/organizations/$new');
   });
 
   it('request failed', () => {

--- a/cypress/e2e/organizations.cy.ts
+++ b/cypress/e2e/organizations.cy.ts
@@ -279,7 +279,7 @@ describe('Test organization add', () => {
     cy.get('#title').should('contain.text', 'New Organization');
 
     cy.get('#id').type('nxt');
-    cy.get('#selectedBillingEntity').click().contains('Engineering').click();
+    cy.get('#selectedBillingEntity').should('contain.text', 'Engineering');
     cy.get('button[type=submit]').click();
     cy.wait('@add');
     cy.url().should('contain', '/zones');
@@ -295,8 +295,6 @@ describe('Test organization add', () => {
     setOrganization(cy);
     setBillingEntities(cy, billingEntityNxt);
     cy.visit('/organizations/$new');
-
-    cy.get('#selectedBillingEntity').click().contains('Engineering').click();
 
     cy.get('#displayName').type('VSHN - the DevOps Company');
     cy.get('#id').clear().type('VSHN $a');
@@ -315,7 +313,6 @@ describe('Test organization add', () => {
     cy.visit('/organizations/$new');
 
     cy.get('#displayName').type('VSHN - the DevOps Company');
-    cy.get('#selectedBillingEntity').click().contains('Engineering').click();
 
     cy.get('#id').clear().type('-1-vshn');
     cy.get('.p-error').should('be.visible').and('contain.text', 'organization ID');

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import * as Sentry from '@sentry/browser';
 import { AppConfigService } from './app-config.service';
 import { IdentityService } from './core/identity.service';
-import { forkJoin } from 'rxjs';
+import { catchError, forkJoin } from 'rxjs';
 import { OrganizationCollectionService } from './store/organization-collection.service';
 import { SelfSubjectAccessReviewCollectionService } from './store/ssar-collection.service';
 import { firstInList, metadataNameFilter } from './store/entity-filter';
@@ -17,6 +17,7 @@ import { BillingEntityPermissions } from './types/billing-entity';
 import { UserCollectionService } from './store/user-collection.service';
 import { ZonePermissions } from './types/zone';
 import { InvitationPermissions } from './types/invitation';
+import { defaultIfStatusCode } from './store/kubernetes-collection.service';
 
 @Component({
   selector: 'app-root',
@@ -47,17 +48,24 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     // initial filter, otherwise teams cannot be loaded if no default organization is defined in the user
     this.organizationService.setFilter(firstInList());
-    this.userService.setFilter(metadataNameFilter(this.identityService.getUsername()));
-    this.userService.getByKey(this.identityService.getUsername()).subscribe({
-      next: (user) => {
-        if (user.spec.preferences?.defaultOrganizationRef) {
-          this.organizationService.setFilter(metadataNameFilter(user.spec.preferences.defaultOrganizationRef));
-        }
-      },
-      error: (err) => {
-        console.warn('could not load the user object:', err.message ?? err);
-      },
-    });
+    const userName = this.identityService.getUsername();
+    this.userService.setFilter(metadataNameFilter(userName));
+    this.userService
+      .getByKey(userName)
+      .pipe(catchError(defaultIfStatusCode(this.userService.newUser(userName), [401, 403, 404])))
+      .subscribe({
+        next: (user) => {
+          if (user.spec.preferences?.defaultOrganizationRef) {
+            this.organizationService.setFilter(metadataNameFilter(user.spec.preferences?.defaultOrganizationRef ?? ''));
+          }
+          if (!user.metadata.resourceVersion) {
+            this.userService.upsertOneInCache(user);
+          }
+        },
+        error: (err) => {
+          console.warn('could not load the user object:', err.message ?? err);
+        },
+      });
 
     this.name = this.identityService.getName();
     this.username = this.identityService.getUsername();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,7 @@ import { catchError, forkJoin } from 'rxjs';
 import { OrganizationCollectionService } from './store/organization-collection.service';
 import { SelfSubjectAccessReviewCollectionService } from './store/ssar-collection.service';
 import { firstInList, metadataNameFilter } from './store/entity-filter';
-import { OrganizationPermissions } from './types/organization';
+import { Organization, OrganizationPermissions } from './types/organization';
 import { BillingEntityPermissions } from './types/billing-entity';
 import { UserCollectionService } from './store/user-collection.service';
 import { ZonePermissions } from './types/zone';
@@ -56,7 +56,9 @@ export class AppComponent implements OnInit {
       .subscribe({
         next: (user) => {
           if (user.spec.preferences?.defaultOrganizationRef) {
-            this.organizationService.setFilter(metadataNameFilter(user.spec.preferences?.defaultOrganizationRef ?? ''));
+            this.organizationService.setFilter(
+              metadataNameFilter(user.spec.preferences?.defaultOrganizationRef ?? '', firstInList<Organization>())
+            );
           }
           if (!user.metadata.resourceVersion) {
             this.userService.upsertOneInCache(user);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,6 +40,7 @@ import { SelfSubjectAccessReviewCollectionService } from './store/ssar-collectio
 import { NavigationService } from './shared/navigation.service';
 import { invitationTokenLocalStorageKey } from './types/invitation';
 import { BrowserStorageService } from './shared/browser-storage.service';
+import { JoinDialogComponent } from './join-dialog/join-dialog.component';
 
 @NgModule({
   declarations: [
@@ -52,6 +53,7 @@ import { BrowserStorageService } from './shared/browser-storage.service';
     IdentityMenuComponent,
     InfoMenuComponent,
     InfoMenuItemComponent,
+    JoinDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -3,18 +3,31 @@
     <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
       <h1 class="pt-0 mt-0 mb-0" i18n id="billingentities-title">Billing</h1>
 
-      <div *ngIf="viewModel.canCreateBilling">
-        <button
-          [routerLink]="['$new']"
-          [queryParams]="{edit: 'y'}"
-          class="w-full white-space-nowrap"
-          id="addButton"
-          pButton
-          pRipple
-        >
-          <fa-icon [icon]="faAdd" class="mr-2" />
-          <span i18n>Add new Billing</span>
-        </button>
+      <div class="flex flex-wrap gap-2">
+        <div>
+          <button
+            (click)="this.joinDialogService.showDialog()"
+            class="mr-2 w-full white-space-nowrap"
+            id="joinOrganizationButton"
+            pButton pRipple
+          >
+            <fa-icon [icon]="faDollarSign" class="mr-2"/>
+            <span i18n>Join Billing</span>
+          </button>
+        </div>
+        <div *ngIf="viewModel.canCreateBilling">
+          <button
+            [routerLink]="['$new']"
+            [queryParams]="{edit: 'y'}"
+            class="w-full white-space-nowrap"
+            id="addButton"
+            pButton
+            pRipple
+          >
+            <fa-icon [icon]="faAdd" class="mr-2" />
+            <span i18n>Add new Billing</span>
+          </button>
+        </div>
       </div>
 
     </div>
@@ -72,7 +85,11 @@
       <p-messages severity="info">
         <ng-template pTemplate="content">
           <fa-icon [icon]="faInfo" />
-          <div class="ml-2" i18n id="no-billingentity-message">No billing entities available.</div>
+          <div class="ml-2" i18n id="no-billingentity-message">
+            No billing address available.
+            <span *ngIf="viewModel.canCreateBilling">Please create one first or ask to join an existing billing address.</span>
+            <span *ngIf="!viewModel.canCreateBilling">Please ask to join an existing billing address.</span>
+          </div>
         </ng-template>
       </p-messages>
     </ng-container>

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -1,11 +1,19 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { BillingEntity } from '../types/billing-entity';
 
-import { faAdd, faEdit, faInfo, faMagnifyingGlass, faUserGroup, faWarning } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAdd,
+  faDollarSign,
+  faEdit,
+  faInfo,
+  faMagnifyingGlass,
+  faUserGroup,
+  faWarning,
+} from '@fortawesome/free-solid-svg-icons';
 import { combineLatestAll, forkJoin, from, map, Observable, of } from 'rxjs';
 import { BillingEntityCollectionService } from '../store/billingentity-collection.service';
 import { switchMap } from 'rxjs/operators';
-import { ActivatedRoute, Router } from '@angular/router';
+import { JoinDialogService } from '../join-dialog/join-dialog.service';
 
 @Component({
   selector: 'app-billing-entity',
@@ -19,13 +27,14 @@ export class BillingEntityComponent implements OnInit {
   faEdit = faEdit;
   faUserGroup = faUserGroup;
   faDetails = faMagnifyingGlass;
+  faAdd = faAdd;
+  faDollarSign = faDollarSign;
 
   payload$?: Observable<ViewModel>;
 
   constructor(
     public billingEntityService: BillingEntityCollectionService,
-    private router: Router,
-    private route: ActivatedRoute
+    public joinDialogService: JoinDialogService
   ) {}
 
   ngOnInit(): void {
@@ -35,16 +44,8 @@ export class BillingEntityComponent implements OnInit {
     ]).pipe(
       switchMap(([entities, canCreateBilling]) => {
         if (entities.length === 0) {
-          if (canCreateBilling) {
-            void this.router.navigate(['$new'], {
-              queryParams: { firstTime: undefined, edit: 'y' },
-              queryParamsHandling: 'merge',
-              relativeTo: this.route,
-            });
-          }
-          // no billing entities
           return of({
-            canCreateBilling: canCreateBilling,
+            canCreateBilling,
             billingModels: [],
           } satisfies ViewModel);
         }
@@ -80,8 +81,6 @@ export class BillingEntityComponent implements OnInit {
       })
     );
   }
-
-  protected readonly faAdd = faAdd;
 }
 
 interface ViewModel {

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { BillingEntity } from '../types/billing-entity';
 
 import { faAdd, faEdit, faInfo, faMagnifyingGlass, faUserGroup, faWarning } from '@fortawesome/free-solid-svg-icons';
-import { combineLatestAll, forkJoin, from, map, Observable, of, take } from 'rxjs';
+import { combineLatestAll, forkJoin, from, map, Observable, of } from 'rxjs';
 import { BillingEntityCollectionService } from '../store/billingentity-collection.service';
 import { switchMap } from 'rxjs/operators';
 
@@ -25,7 +25,7 @@ export class BillingEntityComponent implements OnInit {
 
   ngOnInit(): void {
     this.payload$ = forkJoin([
-      this.billingEntityService.getAllMemoized().pipe(take(1)),
+      this.billingEntityService.getAllMemoized(),
       this.billingEntityService.canCreateBilling(),
     ]).pipe(
       switchMap(([entities, canCreateBilling]) => {

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -5,6 +5,7 @@ import { faAdd, faEdit, faInfo, faMagnifyingGlass, faUserGroup, faWarning } from
 import { combineLatestAll, forkJoin, from, map, Observable, of } from 'rxjs';
 import { BillingEntityCollectionService } from '../store/billingentity-collection.service';
 import { switchMap } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-billing-entity',
@@ -21,7 +22,11 @@ export class BillingEntityComponent implements OnInit {
 
   payload$?: Observable<ViewModel>;
 
-  constructor(public billingEntityService: BillingEntityCollectionService) {}
+  constructor(
+    public billingEntityService: BillingEntityCollectionService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {
     this.payload$ = forkJoin([
@@ -30,6 +35,13 @@ export class BillingEntityComponent implements OnInit {
     ]).pipe(
       switchMap(([entities, canCreateBilling]) => {
         if (entities.length === 0) {
+          if (canCreateBilling) {
+            void this.router.navigate(['$new'], {
+              queryParams: { firstTime: undefined, edit: 'y' },
+              queryParamsHandling: 'merge',
+              relativeTo: this.route,
+            });
+          }
           // no billing entities
           return of({
             canCreateBilling: canCreateBilling,

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -155,6 +155,14 @@ export class BillingEntityFormComponent implements OnInit {
       severity: 'success',
       summary: $localize`Successfully saved`,
     });
+    const firstTime = this.activatedRoute.snapshot.queryParamMap.get('firstTime') === 'y';
+    if (firstTime) {
+      void this.router.navigate(['organizations', '$new'], {
+        queryParams: { edit: undefined },
+        queryParamsHandling: 'merge',
+      });
+      return;
+    }
     // TODO: navigating to previous location with fallback might not work correctly.
     // But since the backend hasn't implemented creating/editing BE yet, it's hard to test.
     const previous = this.navigationService.previousRoute(`../${be.metadata.name}`);

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -97,9 +97,8 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
           this.router.navigateByUrl('/home');
         }
 
-        // Note: The `take(1)`s below ensure our `forkJoin`s actually finish, otherwise they wait forever.
         return forkJoin([
-          this.billingService.getByKeyMemoized(beName).pipe(take(1)),
+          this.billingService.getByKeyMemoized(beName),
           this.rolebindingService
             .getByKeyMemoized(adminClusterRoleBindingName)
             .pipe(catchError(defaultIfNotFound(this.newRoleBinding(adminClusterRoleBindingName))), take(1)),

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.html
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.html
@@ -1,71 +1,101 @@
-<p-dialog
-  (onHide)="onHide()"
-  [(visible)]="showFirstLoginDialog"
-  [draggable]="false"
-  [modal]="true"
-  [resizable]="false"
-  [style]="{ width: '590px' }"
-  appendTo="body"
-  header="Welcome to the APPUiO Cloud Portal"
-  i18n-header>
-  <div class="flex flex-wrap pt-4">
-    <div class="hidden sm:flex bg-blue-50 align-items-center justify-content-center w-4 border-round">
-      <img alt="Image" class="w-9" src="assets/logo_appuio_cloud_rgb.svg" />
+<ng-container *ngrxLet="viewModel$ as vm">
+  <p-dialog
+    *ngIf="vm"
+    (onHide)="onHide()"
+    [(visible)]="vm.showFirstLoginDialog"
+    [draggable]="false"
+    [modal]="true"
+    [resizable]="false"
+    [style]="{ width: '590px' }"
+    appendTo="body"
+    header="Welcome to the APPUiO Cloud Portal"
+    i18n-header>
+    <div class="flex flex-wrap pt-4">
+      <div class="hidden sm:flex bg-blue-50 align-items-center justify-content-center w-4 border-round">
+        <img alt="Image" class="w-9" src="assets/logo_appuio_cloud_rgb.svg"/>
+      </div>
+      <div class="text-700 line-height-3 pl-4 sm:w-8">
+        <p class="mt-0" i18n *ngIf="!vm.userBelongsToOrganization">
+          You do not yet belong to an organization.
+          <span *ngIf="vm.showAddBillingButton || vm.showAddOrganizationButton"> You can either join an existing organization or create a new one.</span>
+          <span *ngIf="!vm.showAddBillingButton && !vm.showAddOrganizationButton"> You can join an existing organization.</span>
+          <span *ngIf="vm.showAddBillingButton"> To create a new organization, first setup Billing.</span>
+        </p>
+        <p class="mt-0" i18n *ngIf="vm.showSetDefaultOrganizationButton">
+          You don't have a default organization set in your settings.
+          Do you want to do that now?
+        </p>
+
+        <p i18n>
+          Don't forget to have a look at the
+          <a href="https://docs.appuio.cloud/user/index.html" target="_blank">documentation</a>
+          of APPUiO Cloud.
+        </p>
+
+        <p-checkbox
+          inputId="hideFirstTimeLoginDialogCheckbox"
+          [binary]="true"
+          [formControl]="hideFirstTimeLoginDialogControl"
+          i18n-label
+          label="Don't show again"
+        />
+      </div>
     </div>
-    <div class="text-700 line-height-3 pl-4 sm:w-8">
-      <p class="mt-0" i18n *ngIf="!userBelongsToOrganization">
-        Unfortunately, you do not yet belong to an organization. You can either join an existing organization or create
-        a new one.
-      </p>
-      <p class="mt-0" i18n *ngIf="userBelongsToOrganization && !userHasDefaultOrganization">
-        You don't yet have a default organization set in your settings. Do you want to do that now?
-      </p>
+    <ng-template pTemplate="footer">
+      <div class="pt-3 flex">
 
-      <p i18n>
-        Don't forget to have a look at the
-        <a href="https://docs.appuio.cloud/user/index.html" target="_blank">documentation</a>
-        of APPUiO Cloud.
-      </p>
+        <button
+          *ngIf="vm.showJoinOrganizationButton"
+          [routerLink]="['organizations']"
+          [queryParams]="{showJoinDialog: 'true'}"
+          (click)="hideDialog(vm)"
+          id="joinOrganizationDialogButton"
+          pButton
+          pRipple
+        >
+          <fa-icon [icon]="faSitemap" class="mr-2"/>
+          <span i18n>Join Organization</span>
+        </button>
 
-      <p-checkbox
-        inputId="hideFirstTimeLoginDialogCheckbox"
-        [binary]="true"
-        [formControl]="hideFirstTimeLoginDialogControl"
-        i18n-label
-        label="Don't show again"></p-checkbox>
-    </div>
-  </div>
-  <ng-template pTemplate="footer">
-    <div class="pt-3 flex">
-      <button
-        *ngIf="!userBelongsToOrganization"
-        (click)="joinOrganization()"
-        id="joinOrganizationDialogButton"
-        pButton
-        pRipple>
-        <fa-icon [icon]="faSitemap" class="mr-2"></fa-icon>
-        <span i18n>Join Organization</span>
-      </button>
+        <button
+          *ngIf="vm.showAddBillingButton"
+          [routerLink]="['billingentities', '$new']"
+          [queryParams]="{edit: 'y', firstTime: 'y'}"
+          (click)="hideDialog(vm)"
+          id="addBillingDialogButton"
+          pButton
+          pRipple
+        >
+          <fa-icon [icon]="faAdd" class="mr-2"/>
+          <span i18n>Add Billing</span>
+        </button>
 
-      <button
-        *ngIf="!userBelongsToOrganization"
-        (click)="addOrganization()"
-        id="addOrganizationDialogButton"
-        pButton
-        pRipple>
-        <fa-icon [icon]="faAdd" class="mr-2"></fa-icon>
-        <span i18n>Add new Organization</span>
-      </button>
+        <button
+          *ngIf="vm.showAddOrganizationButton"
+          [routerLink]="['organizations', '$new']"
+          (click)="hideDialog(vm)"
+          id="addOrganizationDialogButton"
+          pButton
+          pRipple
+        >
+          <fa-icon [icon]="faAdd" class="mr-2"/>
+          <span i18n>Add Organization</span>
+        </button>
 
-      <button
-        *ngIf="userBelongsToOrganization && !userHasDefaultOrganization"
-        (click)="setDefaultOrganization()"
-        id="setDefaultOrganizationDialogButton"
-        pButton
-        pRipple>
-        <fa-icon [icon]="faCoq" class="mr-2"></fa-icon>
-        <span i18n>Set Default Organization</span>
-      </button>
-    </div>
-  </ng-template>
-</p-dialog>
+        <button
+          *ngIf="vm.showSetDefaultOrganizationButton"
+          [routerLink]="['user']"
+          (click)="hideDialog(vm)"
+          id="setDefaultOrganizationDialogButton"
+          pButton
+          pRipple
+        >
+          <fa-icon [icon]="faCoq" class="mr-2"/>
+          <span i18n>Set Default Organization</span>
+        </button>
+
+      </div>
+    </ng-template>
+  </p-dialog>
+
+</ng-container>

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.html
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.html
@@ -17,10 +17,17 @@
       <div class="text-700 line-height-3 pl-4 sm:w-8">
         <p class="mt-0" i18n *ngIf="!vm.userBelongsToOrganization">
           You do not yet belong to an organization.
-          <span *ngIf="vm.showAddBillingButton || vm.showAddOrganizationButton"> You can either join an existing organization or create a new one.</span>
           <span *ngIf="!vm.showAddBillingButton && !vm.showAddOrganizationButton"> You can join an existing organization.</span>
-          <span *ngIf="vm.showAddBillingButton"> To create a new organization, first setup Billing.</span>
+          <span *ngIf="vm.showAddBillingButton || vm.showAddOrganizationButton"> You can either join an existing organization or create a new one.</span>
         </p>
+        <div *ngIf="vm.showAddBillingButton">
+          <span i18n>To get started with APPUiO Cloud, follow the setup procedure.</span>
+          <ol>
+            <li i18n>Add new billing address</li>
+            <li i18n>Add new organization</li>
+            <li i18n>Open the console of an APPUiO Cloud Zone</li>
+          </ol>
+        </div>
         <p class="mt-0" i18n *ngIf="vm.showSetDefaultOrganizationButton">
           You don't have a default organization set in your settings.
           Do you want to do that now?

--- a/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
+++ b/src/app/first-time-login-dialog/first-time-login-dialog.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { ActivatedRoute, ActivationStart, Router } from '@angular/router';
-import { faAdd, faCog, faDollarSign, faSitemap } from '@fortawesome/free-solid-svg-icons';
+import { faAdd, faCog, faSitemap } from '@fortawesome/free-solid-svg-icons';
 import { FormControl } from '@angular/forms';
 import { IdentityService } from '../core/identity.service';
 import { filter, forkJoin, map, Observable, of, take } from 'rxjs';
@@ -24,9 +24,7 @@ export class FirstTimeLoginDialogComponent implements OnInit {
   faSitemap = faSitemap;
   faAdd = faAdd;
   faCoq = faCog;
-  faDollarSign = faDollarSign;
   hideFirstTimeLoginDialogControl = new FormControl(false);
-  nextAction?: 'join' | 'add';
 
   constructor(
     private router: Router,

--- a/src/app/invitations/invitation-detail/invitation-detail.component.ts
+++ b/src/app/invitations/invitation-detail/invitation-detail.component.ts
@@ -14,7 +14,7 @@ import { BillingEntity } from '../../types/billing-entity';
 import { Team } from '../../types/team';
 import { Invitation } from '../../types/invitation';
 import { getBillingEntityFromClusterRoleName } from '../../store/entity-filter';
-import { catchError, combineLatestAll, forkJoin, from, map, Observable, of, take } from 'rxjs';
+import { catchError, combineLatestAll, forkJoin, from, map, Observable, of } from 'rxjs';
 import { OrganizationCollectionService } from '../../store/organization-collection.service';
 import { BillingEntityCollectionService } from '../../store/billingentity-collection.service';
 import { TeamCollectionService } from '../../store/team-collection.service';
@@ -116,7 +116,6 @@ export class InvitationDetailComponent implements OnInit {
 
     const teams$ = teamNames.map((team) =>
       this.teamService.getByKeyMemoized(team).pipe(
-        take(1),
         catchError(() => {
           console.warn(`could not fetch team '${team}' to resolve display name, resort to fallback value`);
           const teamName = team.split('/');
@@ -149,7 +148,6 @@ export class InvitationDetailComponent implements OnInit {
     }
     const billing$ = beNames.map((be) =>
       this.billingService.getByKeyMemoized(be).pipe(
-        take(1),
         catchError(() => {
           console.warn(`could not fetch billing entity '${be}' to resolve display name, resort to fallback value`);
           return of({

--- a/src/app/invitations/invitation-edit/invitation-edit.component.ts
+++ b/src/app/invitations/invitation-edit/invitation-edit.component.ts
@@ -33,7 +33,7 @@ export class InvitationEditComponent implements OnInit {
       this.billingService.canViewBillingEntities$,
     ]).pipe(
       switchMap(([canViewOrganizations, canViewBillingEntities]) => {
-        const organizations$ = canViewOrganizations ? this.organizationService.getAllMemoized().pipe(take(1)) : of([]);
+        const organizations$ = canViewOrganizations ? this.organizationService.getAllMemoized() : of([]);
         const billingEntities$ = canViewBillingEntities ? this.fetchBilling$() : of([]);
         return forkJoin([of(canViewOrganizations), organizations$, of(canViewBillingEntities), billingEntities$]);
       }),

--- a/src/app/invitations/invitations-routing.module.ts
+++ b/src/app/invitations/invitations-routing.module.ts
@@ -5,6 +5,7 @@ import { InvitationsComponent } from './invitations.component';
 import { InvitationPermissions } from '../types/invitation';
 import { InvitationViewComponent } from './invitation-view/invitation-view.component';
 import { InvitationEditComponent } from './invitation-edit/invitation-edit.component';
+import { hideFirstTimeLoginDialogKey } from '../first-time-login-dialog/first-time-login-dialog.component';
 
 const routes: Routes = [
   {
@@ -26,6 +27,9 @@ const routes: Routes = [
   {
     path: ':name',
     component: InvitationViewComponent,
+    data: {
+      [hideFirstTimeLoginDialogKey]: true,
+    },
   },
 ];
 

--- a/src/app/join-dialog/join-dialog.component.html
+++ b/src/app/join-dialog/join-dialog.component.html
@@ -1,7 +1,7 @@
 <p i18n>
-  To join an organization, you must provide your username
+  To join an organization or billing address, you must provide your username
   <code class="font-bold">{{ username }}</code>
-  to the administrator of the organization.
+  to the administrator of the organization or billing address.
 </p>
 
 <a [href]="mailto" class="mr-2 no-underline" pButton pRipple>

--- a/src/app/join-dialog/join-dialog.component.ts
+++ b/src/app/join-dialog/join-dialog.component.ts
@@ -1,14 +1,14 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
-import { IdentityService } from '../../core/identity.service';
+import { IdentityService } from '../core/identity.service';
 
 @Component({
-  selector: 'app-join-organization-dialog',
-  templateUrl: './join-organization-dialog.component.html',
-  styleUrls: ['./join-organization-dialog.component.scss'],
+  selector: 'app-join-dialog',
+  templateUrl: './join-dialog.component.html',
+  styleUrls: ['./join-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class JoinOrganizationDialogComponent implements OnInit {
+export class JoinDialogComponent implements OnInit {
   username = '';
   mailto = '';
   faPaperPlane = faPaperPlane;
@@ -19,7 +19,7 @@ export class JoinOrganizationDialogComponent implements OnInit {
     this.username = this.identityService.getUsername();
     const name = this.identityService.getName();
     const body = encodeURI(
-      $localize`Hi\n\nI would like to join the APPUiO Cloud organization. My username on APPUiO Cloud is "${this.username}".\n\nBest wishes\n${name}`
+      $localize`Hi\n\nI would like to join the APPUiO Cloud organization or billing address. My username on APPUiO Cloud is "${this.username}".\n\nBest wishes\n${name}`
     );
     const subject = encodeURI($localize`Join Organization`);
     this.mailto = `mailto:?subject=${subject}&body=${body}`;

--- a/src/app/join-dialog/join-dialog.service.ts
+++ b/src/app/join-dialog/join-dialog.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { JoinDialogComponent } from './join-dialog.component';
+import { DialogService } from 'primeng/dynamicdialog';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class JoinDialogService {
+  constructor(private dialogService: DialogService) {}
+
+  showDialog(): void {
+    this.dialogService.open(JoinDialogComponent, {
+      modal: true,
+      closable: true,
+      header: $localize`Join Organization or Billing address`,
+    });
+  }
+}

--- a/src/app/organization-selection/organization-selection.component.ts
+++ b/src/app/organization-selection/organization-selection.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { map, Observable, Subscription } from 'rxjs';
 import { SelectItem } from 'primeng/api';
-import { Store } from '@ngrx/store';
 import { faSitemap } from '@fortawesome/free-solid-svg-icons';
 import { FormControl } from '@angular/forms';
 import { OrganizationCollectionService } from '../store/organization-collection.service';
@@ -19,7 +18,7 @@ export class OrganizationSelectionComponent implements OnInit, OnDestroy {
 
   private subscriptions: Subscription[] = [];
 
-  constructor(private store: Store, private organizationService: OrganizationCollectionService) {}
+  constructor(private organizationService: OrganizationCollectionService) {}
 
   ngOnInit(): void {
     this.organizations$ = this.organizationService.getAllMemoized().pipe(

--- a/src/app/organizations/organization-edit/organization-edit.component.html
+++ b/src/app/organizations/organization-edit/organization-edit.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="payload">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
-        <div class="text-3xl font-medium text-900 mb-3">
+        <div id="title" class="text-3xl font-medium text-900 mb-3">
           <span *ngIf="isNew; else isNotNew" i18n>New Organization</span>
           <ng-template #isNotNew>
             {{ payload.organization.metadata.name }}

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -61,19 +61,22 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
           label: be.spec.name ? `${be.spec.name} (${be.metadata.name})` : be.metadata.name,
         };
       });
+    let preselectedBe = this.billingOptions.find(
+      (option) => option.value.metadata.name === this.organization.spec.billingEntityRef
+    );
+    if (!preselectedBe && this.billingEntities.length === 1 && this.new) {
+      preselectedBe = this.billingOptions[0];
+    }
     this.form = this.formBuilder.nonNullable.group({
       displayName: this.organization.spec.displayName,
       organizationId: new FormControl(this.organization.metadata.name, {
         validators: [Validators.required, Validators.pattern(this.organizationNameService.getValidationPattern())],
         nonNullable: true,
       }),
-      billingEntity: new FormControl<SelectItem<BillingEntity> | undefined>(
-        this.billingOptions.find((option) => option.value.metadata.name === this.organization.spec.billingEntityRef),
-        {
-          validators: [Validators.required],
-          nonNullable: true,
-        }
-      ),
+      billingEntity: new FormControl<SelectItem<BillingEntity> | undefined>(preselectedBe, {
+        validators: [Validators.required],
+        nonNullable: true,
+      }),
     });
     if (this.new) {
       const sub = this.form.controls.displayName.valueChanges.subscribe((value) => this.setNameFromDisplayName(value));

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -134,7 +134,16 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
       severity: 'success',
       summary: $localize`Successfully saved`,
     });
-    void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
+    const firstTime = this.activatedRoute.snapshot.queryParamMap.get('firstTime') === 'y';
+    if (firstTime) {
+      void this.router.navigate(['zones'], {
+        queryParams: { edit: undefined, firstTime: undefined },
+        queryParamsHandling: 'merge',
+      });
+      return;
+    }
+    const previous = this.navigationService.previousRoute('..');
+    void this.router.navigate([previous.path], { relativeTo: this.activatedRoute, queryParams: previous.queryParams });
   }
 
   private saveOrUpdateFailure(err: Error): void {

--- a/src/app/organizations/organizations.component.html
+++ b/src/app/organizations/organizations.component.html
@@ -1,48 +1,64 @@
-<div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
-  <h1 class="pt-0 mt-0 mb-0" i18n id="organizations-title">Organizations</h1>
+<ng-container *ngrxLet="organizations$ as vm; suspenseTpl: loading; error as err">
 
-  <div class="flex flex-wrap gap-2">
-    <div>
-      <button (click)="openJoinOrganizationDialog()" class="mr-2 w-full white-space-nowrap" id="joinOrganizationButton"
-        pButton pRipple>
-        <fa-icon [icon]="faSitemap" class="mr-2"></fa-icon>
-        <span i18n>Join Organization</span>
-      </button>
+  <ng-container *ngIf="vm">
+    <div class="flex flex-row flex-wrap justify-content-between mb-2 gap-2">
+      <h1 class="pt-0 mt-0 mb-0" i18n id="organizations-title">Organizations</h1>
+
+      <div class="flex flex-wrap gap-2">
+        <div>
+          <button
+            (click)="openJoinOrganizationDialog()"
+            class="mr-2 w-full white-space-nowrap"
+            id="joinOrganizationButton"
+            pButton pRipple
+          >
+            <fa-icon [icon]="faSitemap" class="mr-2"/>
+            <span i18n>Join Organization</span>
+          </button>
+        </div>
+
+        <div *ngIf="vm.canAddOrganizations">
+          <button
+            [routerLink]="['$new']"
+            class="w-full white-space-nowrap" id="addOrganizationButton"
+            pButton pRipple
+          >
+            <fa-icon [icon]="faAdd" class="mr-2"/>
+            <span i18n>Add new Organization</span>
+          </button>
+        </div>
+      </div>
     </div>
 
-    <ng-container *ngIf="canAddOrganizations$ | ngrxPush">
-      <div>
-        <button [routerLink]="['$new']" class="w-full white-space-nowrap" id="addOrganizationButton" pButton pRipple>
-          <fa-icon [icon]="faAdd" class="mr-2"></fa-icon>
-          <span i18n>Add new Organization</span>
-        </button>
-      </div>
-    </ng-container>
-  </div>
-</div>
-
-<ng-container *ngrxLet="organizations$ as orgPayload; suspenseTpl: loading; error as err">
-  <ng-container *ngIf="orgPayload">
-    <ng-container *ngFor="let dto of orgPayload; index as i">
+    <ng-container *ngFor="let dto of vm.organizations">
       <div class="surface-card p-4 shadow-2 border-round mb-4">
         <div class="flex flex-row justify-content-between">
           <div class="text-3xl font-medium text-900 mb-3">
             {{ dto.organization.metadata.name }}
           </div>
           <div>
-            <a *ngIf="dto.organization.spec.billingEntityRef"
+            <a
+              *ngIf="dto.organization.spec.billingEntityRef"
               [routerLink]="['/billingentities', dto.organization.spec.billingEntityRef]"
-              class="text-blue-500 hover:text-primary cursor-pointer mr-1" i18n-title
-              title="View '{{ dto.organization.status?.billingEntityName ?? dto.organization.spec.billingEntityRef }}'">
-              <fa-icon [icon]="faDollarSign"></fa-icon>
+              class="text-blue-500 hover:text-primary cursor-pointer ml-3"
+              i18n-title title="View '{{ dto.organization.status?.billingEntityName ?? dto.organization.spec.billingEntityRef }}'"
+            >
+              <fa-icon [icon]="faDollarSign"/>
             </a>
-            <a *ngIf="dto.canViewMembers$ | ngrxPush" [routerLink]="[dto.organization.metadata.name, 'members']"
-              class="text-blue-500 hover:text-primary cursor-pointer mr-2" i18n-title title="Edit members">
-              <fa-icon [icon]="faUserGroup"></fa-icon>
+            <a
+              *ngIf="dto.canViewMembers"
+              [routerLink]="[dto.organization.metadata.name, 'members']"
+              class="text-blue-500 hover:text-primary cursor-pointer ml-3"
+              i18n-title title="Edit members"
+            >
+              <fa-icon [icon]="faUserGroup"/>
             </a>
-            <a *ngIf="dto.canEdit$ | ngrxPush" [routerLink]="[dto.organization.metadata.name]"
-              class="text-blue-500 hover:text-primary cursor-pointer" i18n-title title="Edit organization">
-              <fa-icon [icon]="faEdit"></fa-icon>
+            <a
+              *ngIf="dto.canEdit" [routerLink]="[dto.organization.metadata.name]"
+              class="text-blue-500 hover:text-primary cursor-pointer ml-3"
+              i18n-title title="Edit organization"
+            >
+              <fa-icon [icon]="faEdit"/>
             </a>
           </div>
         </div>
@@ -58,22 +74,21 @@
         </div>
       </div>
     </ng-container>
-  </ng-container>
 
-  <ng-container *ngIf="orgPayload?.length === 0 && !err">
-    <p-messages severity="info">
-      <ng-template pTemplate="content">
-        <fa-icon [icon]="faInfo"></fa-icon>
-        <div class="ml-2" i18n id="no-organization-message">No organizations available.</div>
-      </ng-template>
-    </p-messages>
+    <ng-container *ngIf="vm.organizations.length === 0 && !err">
+      <p-messages severity="info">
+        <ng-template pTemplate="content">
+          <fa-icon [icon]="faInfo"/>
+          <div class="ml-2" i18n id="no-organization-message">No organizations available.</div>
+        </ng-template>
+      </p-messages>
+    </ng-container>
   </ng-container>
-
 
   <ng-container *ngIf="err">
     <p-messages severity="error">
       <ng-template pTemplate="content">
-        <fa-icon [icon]="faWarning"></fa-icon>
+        <fa-icon [icon]="faWarning"/>
         <div class="ml-2" i18n id="failure-message">Organizations could not be loaded.</div>
       </ng-template>
     </p-messages>

--- a/src/app/organizations/organizations.component.html
+++ b/src/app/organizations/organizations.component.html
@@ -7,7 +7,7 @@
       <div class="flex flex-wrap gap-2">
         <div>
           <button
-            (click)="openJoinOrganizationDialog()"
+            (click)="this.joinDialogService.showDialog()"
             class="mr-2 w-full white-space-nowrap"
             id="joinOrganizationButton"
             pButton pRipple
@@ -79,7 +79,11 @@
       <p-messages severity="info">
         <ng-template pTemplate="content">
           <fa-icon [icon]="faInfo"/>
-          <div class="ml-2" i18n id="no-organization-message">No organizations available.</div>
+          <div class="ml-2" i18n id="no-organization-message">
+            No organizations available.
+            <span *ngIf="vm.canAddOrganizations">Please create one first or ask to join an existing organization.</span>
+            <span *ngIf="!vm.canAddOrganizations">Please ask to join an existing organization.</span>
+          </div>
         </ng-template>
       </p-messages>
     </ng-container>

--- a/src/app/organizations/organizations.component.ts
+++ b/src/app/organizations/organizations.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
-import { map, Observable, Subscription, take } from 'rxjs';
+import { combineLatestAll, filter, forkJoin, from, map, Observable, of, Subscription, switchMap } from 'rxjs';
 import {
   faAdd,
   faDollarSign,
@@ -12,17 +11,11 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { DialogService } from 'primeng/dynamicdialog';
 import { JoinOrganizationDialogComponent } from './join-organization-dialog/join-organization-dialog.component';
-import { selectQueryParam } from '../store/router.selectors';
 import { ActivatedRoute, Router } from '@angular/router';
 import { OrganizationCollectionService } from '../store/organization-collection.service';
 import { Organization } from '../types/organization';
 import { OrganizationMembersCollectionService } from '../store/organizationmembers-collection.service';
-
-interface OrganizationConfig {
-  organization: Organization;
-  canEdit$: Observable<boolean>;
-  canViewMembers$: Observable<boolean>;
-}
+import { BillingEntityCollectionService } from '../store/billingentity-collection.service';
 
 @Component({
   selector: 'app-organizations',
@@ -38,47 +31,82 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
   faSitemap = faSitemap;
   faUserGroup = faUserGroup;
   faDollarSign = faDollarSign;
-  private showJoinDialogSubscription?: Subscription;
-  organizations$?: Observable<OrganizationConfig[]>;
-  canAddOrganizations$?: Observable<boolean>;
+  subscriptions: Subscription[] = [];
+
+  organizations$?: Observable<ViewModel>;
 
   constructor(
-    private store: Store,
     private dialogService: DialogService,
     private router: Router,
     private activatedRoute: ActivatedRoute,
     public organizationService: OrganizationCollectionService,
-    private organizationMembersService: OrganizationMembersCollectionService
+    private organizationMembersService: OrganizationMembersCollectionService,
+    private billingService: BillingEntityCollectionService
   ) {}
 
   ngOnInit(): void {
-    this.canAddOrganizations$ = this.organizationService.canAddOrganizations$;
-
-    this.organizations$ = this.organizationService.getAllMemoized().pipe(
-      take(1),
-      map((orgs) =>
-        orgs.map((org) => {
-          return {
-            organization: org,
-            canEdit$: this.organizationService.canEditOrganization(org),
-            canViewMembers$: this.organizationMembersService.canViewMembers(org.metadata.name),
-          } satisfies OrganizationConfig;
-        })
-      )
+    this.organizations$ = forkJoin([
+      this.organizationService.canAddOrganizations$,
+      this.billingService.canViewBillingEntities$,
+      this.organizationService.getAllMemoized(),
+    ]).pipe(
+      switchMap(([canAddOrganizations, canViewBilling, orgs]) => {
+        if (orgs.length === 0 && canAddOrganizations && canViewBilling) {
+          void this.router.navigate(['organizations', '$new'], {
+            queryParams: { firstTime: undefined },
+            queryParamsHandling: 'merge',
+          });
+          return forkJoin([of(canAddOrganizations), of([])]);
+        }
+        return forkJoin([of(canAddOrganizations), this.fetchOrganizationData$(orgs)]);
+      }),
+      map(([canAddOrganizations, orgVMList]) => {
+        const vm: ViewModel = {
+          canAddOrganizations,
+          organizations: orgVMList,
+        };
+        return vm;
+      })
     );
-    this.showJoinDialogSubscription = this.store
-      .select(selectQueryParam('showJoinDialog'))
-      // eslint-disable-next-line ngrx/no-store-subscription
-      .subscribe((showJoinDialog) => {
-        if (showJoinDialog) {
+
+    this.subscriptions.push(
+      this.activatedRoute.queryParamMap
+        .pipe(
+          map((q) => q.get('showJoinDialog')),
+          filter((v) => v === 'true')
+        )
+        .subscribe(() => {
           this.openJoinOrganizationDialog();
-          this.router.navigate([], {
+          void this.router.navigate([], {
             relativeTo: this.activatedRoute,
             queryParams: { showJoinDialog: undefined },
             queryParamsHandling: 'merge',
           });
-        }
-      });
+        })
+    );
+  }
+
+  private fetchOrganizationData$(orgs: Organization[]): Observable<OrganizationViewModel[]> {
+    if (orgs.length === 0) {
+      return of([]);
+    }
+    const list = orgs.map((org) => {
+      return forkJoin([
+        of(org),
+        this.organizationService.canEditOrganization(org),
+        this.organizationMembersService.canViewMembers(org.metadata.name),
+      ]).pipe(
+        map(([organization, canEdit, canViewMembers]) => {
+          const orgVM: OrganizationViewModel = {
+            organization,
+            canEdit,
+            canViewMembers,
+          };
+          return orgVM;
+        })
+      );
+    });
+    return from(list).pipe(combineLatestAll());
   }
 
   openJoinOrganizationDialog(): void {
@@ -90,6 +118,17 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.showJoinDialogSubscription?.unsubscribe();
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
   }
+}
+
+interface ViewModel {
+  organizations: OrganizationViewModel[];
+  canAddOrganizations: boolean;
+}
+
+interface OrganizationViewModel {
+  organization: Organization;
+  canEdit: boolean;
+  canViewMembers: boolean;
 }

--- a/src/app/organizations/organizations.module.ts
+++ b/src/app/organizations/organizations.module.ts
@@ -6,7 +6,6 @@ import { OrganizationEditComponent } from './organization-edit/organization-edit
 import { SharedModule } from '../shared/shared.module';
 import { OrganizationFormComponent } from './organization-form/organization-form.component';
 import { OrganizationMembersEditComponent } from './organization-members-edit/organization-members-edit.component';
-import { JoinOrganizationDialogComponent } from './join-organization-dialog/join-organization-dialog.component';
 
 @NgModule({
   declarations: [
@@ -14,7 +13,6 @@ import { JoinOrganizationDialogComponent } from './join-organization-dialog/join
     OrganizationEditComponent,
     OrganizationFormComponent,
     OrganizationMembersEditComponent,
-    JoinOrganizationDialogComponent,
   ],
   imports: [SharedModule, OrganizationsRoutingModule],
 })

--- a/src/app/store/entity-filter.ts
+++ b/src/app/store/entity-filter.ts
@@ -1,12 +1,19 @@
 import { KubeObject } from '../types/entity';
 
-export function metadataNameFilter(metadataName: string): (entities: KubeObject[]) => KubeObject[] {
+export function metadataNameFilter<T extends KubeObject>(
+  metadataName: string,
+  defaultFn?: (entities: T[]) => T[]
+): (entities: T[]) => T[] {
   return function (entities) {
-    return entities.filter((entity) => entity.metadata.name === metadataName);
+    const entity = entities.find((e) => e.metadata.name === metadataName);
+    if (entity) {
+      return [entity];
+    }
+    return defaultFn ? defaultFn(entities) : entities.filter((e) => e.metadata.name === metadataName);
   };
 }
 
-export function firstInList<T>(): (entity: T[]) => T[] {
+export function firstInList<T>(): (entities: T[]) => T[] {
   return function (entities) {
     if (entities.length === 0) {
       return [];

--- a/src/app/store/kubernetes-collection.service.ts
+++ b/src/app/store/kubernetes-collection.service.ts
@@ -113,7 +113,7 @@ export class KubernetesCollectionService<T extends KubeObject> extends EntityCol
       take(1),
       switchMap(() => {
         if (this.memoizedAllEntities) {
-          return this.entities$;
+          return this.entities$.pipe(take(1));
         }
         return this.getAll(options);
       })

--- a/src/app/store/organization-collection.service.ts
+++ b/src/app/store/organization-collection.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data';
 import { Organization, OrganizationPermissions } from '../types/organization';
 import { organizationEntityKey } from './entity-metadata-map';
-import { combineLatest, filter, forkJoin, map, Observable } from 'rxjs';
+import { filter, forkJoin, map, Observable } from 'rxjs';
 import { KubernetesCollectionService } from './kubernetes-collection.service';
 import { SelfSubjectAccessReviewCollectionService } from './ssar-collection.service';
 import { Verb } from './app.reducer';
@@ -13,7 +13,6 @@ import { metadataNameFilter } from './entity-filter';
   providedIn: 'root',
 })
 export class OrganizationCollectionService extends KubernetesCollectionService<Organization> {
-  isEmptyAndLoaded$: Observable<boolean>;
   canAddOrganizations$: Observable<boolean>;
   canViewOrganizations$: Observable<boolean>;
   selectedOrganization$: Observable<Organization>;
@@ -23,17 +22,12 @@ export class OrganizationCollectionService extends KubernetesCollectionService<O
     private permissionService: SelfSubjectAccessReviewCollectionService
   ) {
     super(organizationEntityKey, elementsFactory);
-    this.isEmptyAndLoaded$ = combineLatest([this.loaded$, this.entities$], (loaded, entities) => {
-      if (loaded) {
-        return entities.length === 0;
-      }
-      return false;
-    });
 
-    this.canAddOrganizations$ = forkJoin([
-      permissionService.isAllowed(OrganizationPermissions.group, OrganizationPermissions.resource, Verb.Create),
-      permissionService.isAllowed(BillingEntityPermissions.group, BillingEntityPermissions.resource, Verb.List),
-    ]).pipe(map(([orgCreateAllowed, beListAllowed]) => orgCreateAllowed && beListAllowed));
+    this.canAddOrganizations$ = permissionService.isAllowed(
+      OrganizationPermissions.group,
+      OrganizationPermissions.resource,
+      Verb.Create
+    );
 
     this.canViewOrganizations$ = permissionService.isAllowed(
       OrganizationPermissions.group,

--- a/src/app/store/user-collection.service.ts
+++ b/src/app/store/user-collection.service.ts
@@ -19,4 +19,15 @@ export class UserCollectionService extends KubernetesCollectionService<User> {
       map((users) => users[0])
     );
   }
+
+  newUser(userName: string): User {
+    return {
+      kind: 'User',
+      apiVersion: 'appuio.io/v1',
+      metadata: {
+        name: userName,
+      },
+      spec: {},
+    };
+  }
 }


### PR DESCRIPTION
## Summary

Closes #524 
This PR is a first iteration of a wizard-like flow for first-time users. It reworks the first-time-login-dialog and the behaviour in the Billing and organization list views.

* Updates the first-time-login-dialog with new buttons and text, encouraging to create Billing entities instead.
* When listing the organizations and it's still the first-time-setup, it will directly open the "new organization" form.
* Handle the case where the user settings in the `User` object doesn't yet exist (aka we don't know the default organization).

`/billingentities` redirects to `/billingentities/$new` if 
1. billing list is empty
1. user can create billing

`/organizations` redirects to `/organizations/$new` if
1. organization list is empty
1. user can list billing
1. user can create organization

In simpler words: Provided the user have enough permissions, instead of "no <entity> available" in the list, they will get redirected to the respective creation forms.

The happy-path flow for new users is generally:
`Dialog -> Add Billing -> Add Organization -> View Zones`

## First Login Dialog

### Newly logged in user
```yaml
organizations: 0
billingEntities: 0
```
![image](https://user-images.githubusercontent.com/12159026/232729287-bd197cc5-cb1b-489a-9795-94a21d5c57ba.png)

### Newly logged in user with billing
```yaml
organizations: 0
billingEntities: 1
```
![image](https://user-images.githubusercontent.com/12159026/231763195-93e60317-9f7d-4db8-a7c1-1da51f8f94dc.png)


### User that has organization, but not a default one
```yaml
organizations: 1
billingEntities: 1
```
![image](https://user-images.githubusercontent.com/12159026/231762678-af0ebc19-7270-4487-b89e-018dc0313432.png)


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
