### PR TITLE
Graceful degradation of empty country list

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -15,7 +15,7 @@ export interface AppConfig {
     zoneURLLabels: { [key: string]: string };
     consoleUrlKey: string;
   };
-  countries: { code?: string; name: string }[];
+  countries?: { code?: string; name: string }[];
 }
 
 export interface ZoneConfig {

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.html
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.html
@@ -49,7 +49,9 @@
         filterBy="name"
         [required]="true"
         placeholder="Select Country"
+        emptyMessage="No results found, please try a hard reload of the page"
         i18n-placeholder
+        i18n-emptyMessage
         [styleClass]="'mb-2'"
       />
       <small i18n>

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -39,7 +39,7 @@ export class BillingEntityFormComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.countryOptions = this.appConfig.getConfiguration().countries;
+    this.countryOptions = this.appConfig.getConfiguration().countries ?? [];
     this.billingEntity = structuredClone(this.billingEntity); // make fields writable if editing existing BE.
     const spec = this.billingEntity.spec;
     const companyEmails = spec.emails?.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })) ?? [];


### PR DESCRIPTION

## Summary

This should cover the error messages/reporter for users where the config.json is missing the country list caused by browser cache.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
