### PR TITLE
Add polyfill for structuredClone

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -51,3 +51,21 @@ import 'zone.js'; // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+
+/**
+ * structuredClone is somewhat recent, thus maybe not available in all browsers.
+ */
+(function () {
+  if (typeof structuredClone !== 'undefined') {
+    return;
+  }
+  function structuredClone<T>(obj: T): T {
+    const jsonString = JSON.stringify(obj);
+    return JSON.parse(jsonString);
+  }
+  if (typeof window !== 'undefined') {
+    window.structuredClone = structuredClone;
+  } else {
+    throw new Error('Could not attach structuredClone polyfill to the window object');
+  }
+})();


### PR DESCRIPTION

## Summary

Some older browsers don't support structuredClone().
The result is that most objects like Organizations or Billing Entities can't be updated with older browsers such as Safari 14 (which is still used at VSHN according to bug reporter).
This PR adds a polyfill for this function so older browsers work, but it may not be the most performant solution. (Arguably, we encourage users to use the latest browser version anyway.)


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
