### PR TITLE
Ensure zones are sorted

### DIFF
--- a/cypress/e2e/zones.cy.ts
+++ b/cypress/e2e/zones.cy.ts
@@ -18,7 +18,7 @@ describe('Test zones', () => {
   it('list with two entries', () => {
     cy.setPermission({ verb: 'list', ...ZonePermissions });
     cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/zones', {
-      body: { items: [zoneCloudscale1, zoneCloudscale2] },
+      body: { items: [zoneCloudscale2, zoneCloudscale1] },
     });
     cy.visit('/zones');
     cy.get('#zones-title').should('contain.text', 'Zones');

--- a/cypress/fixtures/zone.ts
+++ b/cypress/fixtures/zone.ts
@@ -12,7 +12,7 @@ export interface ZoneConfig {
 }
 
 export const zoneCloudscale1 = createZone({
-  name: 'cloudscale.ch AG',
+  name: 'cloudscale-lpg-1',
   displayName: 'cloudscale.ch LPG 0',
   features: { kubernetesVersion: '1.21', openshiftVersion: '4.8', sdnPlugin: 'OVN-Kubernetes' },
   cname: 'cname.cloudscale-lpg-0.appuio.cloud',

--- a/src/app/zones/zones.component.ts
+++ b/src/app/zones/zones.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { faInfoCircle, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { Zone } from '../types/zone';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { ZoneCollectionService } from '../store/zone-collection.service';
 
 @Component({
@@ -19,6 +19,8 @@ export class ZonesComponent implements OnInit {
   constructor(private zoneService: ZoneCollectionService) {}
 
   ngOnInit(): void {
-    this.zones$ = this.zoneService.getAllMemoized();
+    this.zones$ = this.zoneService
+      .getAllMemoized()
+      .pipe(map((zones) => zones.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name))));
   }
 }


### PR DESCRIPTION


## Summary

Fixes #543

This might be an issue with Kubernetes version 1.24 and below, or OpenShift. On local-env with K8s 1.25, this issue about unsorted zones doesn't occur...

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
