### PR TITLE
Unify notifications

### DIFF
--- a/cypress/e2e/invitations-accept.cy.ts
+++ b/cypress/e2e/invitations-accept.cy.ts
@@ -116,7 +116,7 @@ describe('Test invitation accept for existing user', () => {
     cy.wait('@createInvitationRedeemRequest');
     cy.get('#title').should('contain.text', 'Invitation');
     cy.get('.flex-row > .text-3xl', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
-    cy.get('p-toast').should('contain.text', 'Redeem successful');
+    cy.get('p-toast').should('contain.text', 'Invitation accepted');
   });
 
   it('should accept but display message if some targets failed', () => {
@@ -236,7 +236,7 @@ describe('Test invitation accept for existing user', () => {
     cy.wait('@getInvitation');
     cy.get('#title').should('contain.text', 'Invitation');
     cy.get('.flex-row > .text-3xl').should('contain.text', 'dev@nxt.engineering');
-    cy.get('p-toast').should('contain.text', 'Redeem successful');
+    cy.get('p-toast').should('contain.text', 'Invitation accepted');
 
     cy.get('app-navbar-item').contains('Organizations').click();
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'vshn');
@@ -286,7 +286,7 @@ describe('Test invitation accept for existing user', () => {
 
     cy.get('app-navbar-item').contains('Organizations').click();
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
-    cy.get('p-toast', { timeout: 10000 }).should('contain.text', 'Redeem successful');
+    cy.get('p-toast', { timeout: 10000 }).should('contain.text', 'Invitation accepted');
   });
 });
 
@@ -332,7 +332,7 @@ describe('Test invitation accept for new user', () => {
     cy.wait('@getInvitation');
     cy.get('#title').should('contain.text', 'Invitation');
     cy.get('.flex-row > .text-3xl', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
-    cy.get('p-toast').should('contain.text', 'Redeem successful');
+    cy.get('p-toast').should('contain.text', 'Invitation accepted');
   });
 
   it('should accept but display message if some targets failed', () => {

--- a/cypress/e2e/zones.cy.ts
+++ b/cypress/e2e/zones.cy.ts
@@ -67,6 +67,7 @@ describe('Test zones', () => {
   it('no permission', () => {
     cy.visit('/zones');
     cy.get('h1').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('p-toast').should('contain.text', 'Error');
   });
 });
 
@@ -118,5 +119,6 @@ describe('Test single zone', () => {
   it('no permission', () => {
     cy.visit('/zones/cloudscale-lpg-0');
     cy.get('h1').should('contain.text', 'Welcome to the APPUiO Cloud Portal');
+    cy.get('p-toast').should('contain.text', 'Error');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { Store } from '@ngrx/store';
 import { selectOrganizationSelectionEnabled } from './store/app.selectors';
 import { Verb } from './store/app.reducer';
@@ -30,6 +29,7 @@ import { StyleClassModule } from 'primeng/styleclass';
 import { NgFor, NgIf } from '@angular/common';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ToastModule } from 'primeng/toast';
+import { NotificationService } from './core/notification.service';
 
 @Component({
   selector: 'app-root',
@@ -63,14 +63,14 @@ export class AppComponent implements OnInit {
   faComment = faComment;
 
   constructor(
-    private oauthService: OAuthService,
     private store: Store,
     private appConfigService: AppConfigService,
     private identityService: IdentityService,
     private organizationService: OrganizationCollectionService,
     private permissionService: SelfSubjectAccessReviewCollectionService,
     private userService: UserCollectionService,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -94,6 +94,9 @@ export class AppComponent implements OnInit {
         },
         error: (err) => {
           console.warn('could not load the user object:', err.message ?? err);
+          this.notificationService.showErrorMessage(
+            $localize`Could not load user data. Please try again in a few minutes.`
+          );
         },
       });
 

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -198,6 +198,6 @@ export class BillingEntityFormComponent implements OnInit {
   }
 
   private saveOrUpdateFailure(): void {
-    this.notificationService.showErrorMessage($localize`Failed to save billing details. Please try again later.`);
+    this.notificationService.showErrorMessage($localize`Failed to save billing details.`);
   }
 }

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -154,12 +154,12 @@ export class BillingEntityFormComponent implements OnInit {
     if (this.isNewBillingEntity(be)) {
       this.billingService.add(be).subscribe({
         next: (result) => this.saveOrUpdateSuccess(result),
-        error: (err) => this.saveOrUpdateFailure(err),
+        error: this.saveOrUpdateFailure,
       });
     } else {
       this.billingService.update(be).subscribe({
         next: (result) => this.saveOrUpdateSuccess(result),
-        error: (err) => this.saveOrUpdateFailure(err),
+        error: this.saveOrUpdateFailure,
       });
     }
   }
@@ -197,7 +197,7 @@ export class BillingEntityFormComponent implements OnInit {
     });
   }
 
-  private saveOrUpdateFailure(err: Error): void {
+  private saveOrUpdateFailure(): void {
     this.notificationService.showErrorMessage($localize`Failed to save billing details. Please try again later.`);
   }
 }

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -6,7 +6,6 @@ import { BillingEntity } from '../../types/billing-entity';
 import { BillingForm } from './billingentity-form.types';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppConfigService } from '../../app-config.service';
-import { MessageService } from 'primeng/api';
 import { NavigationService } from '../../shared/navigation.service';
 import { multiEmail, sameEntries } from './billingentity-form.util';
 import { filter } from 'rxjs';
@@ -20,6 +19,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { ChipsModule } from 'primeng/chips';
 import { DividerModule } from 'primeng/divider';
 import { InputTextModule } from 'primeng/inputtext';
+import { NotificationService } from '../../core/notification.service';
 
 @Component({
   selector: 'app-billingentity-form',
@@ -58,8 +58,8 @@ export class BillingEntityFormComponent implements OnInit {
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private navigationService: NavigationService,
-    private messageService: MessageService,
-    private appConfig: AppConfigService
+    private appConfig: AppConfigService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -178,10 +178,7 @@ export class BillingEntityFormComponent implements OnInit {
 
   private saveOrUpdateSuccess(be: BillingEntity): void {
     this.billingService.resetMemoization();
-    this.messageService.add({
-      severity: 'success',
-      summary: $localize`Successfully saved`,
-    });
+    this.notificationService.showSuccessMessage($localize`Successfully saved billing`);
     const firstTime = this.activatedRoute.snapshot.queryParamMap.get('firstTime') === 'y';
     if (firstTime) {
       void this.router.navigate(['organizations', '$new'], {
@@ -201,15 +198,6 @@ export class BillingEntityFormComponent implements OnInit {
   }
 
   private saveOrUpdateFailure(err: Error): void {
-    let detail = '';
-    if ('message' in err) {
-      detail = err.message;
-    }
-    this.messageService.add({
-      severity: 'error',
-      summary: $localize`Error`,
-      sticky: true,
-      detail,
-    });
+    this.notificationService.showErrorMessage($localize`Failed to save billing details. Please try again later.`);
   }
 }

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -260,7 +260,7 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
         );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.route });
       },
-      error: (error) => {
+      error: () => {
         this.notificationService.showErrorMessage(
           $localize`Could not save Billing ${payload.billingEntity.metadata.name}. Please try again later.`
         );

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -262,7 +262,7 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
       },
       error: () => {
         this.notificationService.showErrorMessage(
-          $localize`Could not save Billing ${payload.billingEntity.metadata.name}. Please try again later.`
+          $localize`Could not save Billing ${payload.billingEntity.metadata.name}.`
         );
       },
     });

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -7,7 +7,7 @@ import { faClose, faSave, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { FormArray, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ClusterRoleBinding } from '../../types/clusterrole-binding';
 import { ClusterRolebindingCollectionService } from '../../store/clusterrolebinding-collection.service';
-import { MessageService, SharedModule } from 'primeng/api';
+import { SharedModule } from 'primeng/api';
 import { UserCollectionService } from '../../store/user-collection.service';
 import { User } from 'src/app/types/user';
 import { switchMap } from 'rxjs/operators';
@@ -26,6 +26,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
+import { NotificationService } from '../../core/notification.service';
 
 interface Payload {
   billingEntity: BillingEntity;
@@ -77,7 +78,7 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
   isRemovingOwnUser = false;
 
   readonly userNamePrefix = 'appuio#';
-  private subscriptions: Subscription[] = [];
+  subscriptions: Subscription[] = [];
 
   constructor(
     private route: ActivatedRoute,
@@ -86,8 +87,8 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
     private billingService: BillingEntityCollectionService,
     private roleService: ClusterRoleCollectionService,
     public rolebindingService: ClusterRolebindingCollectionService,
-    private messageService: MessageService,
-    private userService: UserCollectionService
+    private userService: UserCollectionService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -110,17 +111,13 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
     ]).pipe(
       switchMap(([canViewBE, canEditViewer, canEditAdmins]) => {
         if (!canViewBE) {
-          this.messageService.add({
-            severity: 'error',
-            summary: `You don't have permissions to view Billing ${beName}.`,
-          });
+          this.notificationService.showErrorMessage($localize`You don't have permissions to view Billing ${beName}.`);
           this.router.navigateByUrl('/home');
         }
         if (!canEditViewer || !canEditAdmins) {
-          this.messageService.add({
-            severity: 'error',
-            summary: `You don't have enough permissions to edit members of Billing ${beName}.`,
-          });
+          this.notificationService.showErrorMessage(
+            $localize`You don't have permissions to edit members of Billing ${beName}.`
+          );
           this.router.navigateByUrl('/home');
         }
 
@@ -258,19 +255,15 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
     });
     forkJoin(upsert$).subscribe({
       next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: $localize`Successfully saved`,
-        });
+        this.notificationService.showSuccessMessage(
+          $localize`Successfully saved Billing ${payload.billingEntity.metadata.name}.`
+        );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.route });
       },
       error: (error) => {
-        this.messageService.add({
-          severity: 'error',
-          summary: $localize`Error`,
-          detail: error.message,
-          sticky: true,
-        });
+        this.notificationService.showErrorMessage(
+          $localize`Could not save Billing ${payload.billingEntity.metadata.name}. Please try again later.`
+        );
       },
     });
   }

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { MessageService } from 'primeng/api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationService {
+  constructor(private messageService: MessageService) {}
+
+  /**
+   * Shows an error message as a toast, with 'Error' as the title.
+   * This message is sticky and closable.
+   * @param message
+   */
+  showErrorMessage(message: string) {
+    this.messageService.add({
+      severity: 'error',
+      summary: $localize`Error`,
+      detail: message,
+      closable: true,
+      sticky: true,
+    });
+  }
+
+  /**
+   * Shows an error message with custom title as a toast.
+   * This message is sticky and closable.
+   * @param title
+   * @param message
+   */
+  showErrorMessageWithTitle(title: string, message: string) {
+    this.messageService.add({
+      severity: 'warn',
+      summary: title,
+      detail: message,
+      closable: true,
+      sticky: true,
+    });
+  }
+
+  /**
+   * Shows a success message as toast.
+   * Success messages are not sticky,
+   * so there should be no actionable items or detailed info in the message.
+   * When a success toast is used, the screen should also reflect the success of the user's action,
+   * e.g. when editing a list item showing the updated list.
+   * @param message
+   */
+  showSuccessMessage(message: string) {
+    this.messageService.add({
+      severity: 'success',
+      summary: $localize`Success`,
+      detail: message,
+      closable: true,
+      sticky: false,
+    });
+  }
+
+  /**
+   * Shows an info message and title as toast.
+   * The message is sticky and closable.
+   * Use this sparingly, as most information should be shown in the UI instead of a toast.
+   * @param title
+   * @param message
+   */
+  showInfoMessage(title: string, message: string) {
+    this.messageService.add({
+      severity: 'info',
+      summary: title,
+      detail: message,
+      closable: true,
+      sticky: true,
+    });
+  }
+}

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -56,6 +56,11 @@ export class NotificationService {
     });
   }
 
+  /**
+   * Shows a warning message as toast.
+   * The message is sticky and closable.
+   * @param message
+   */
   showWarningMessage(message: string) {
     this.messageService.add({
       severity: 'warn',

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -30,7 +30,7 @@ export class NotificationService {
    */
   showErrorMessageWithTitle(title: string, message: string) {
     this.messageService.add({
-      severity: 'warn',
+      severity: 'error',
       summary: title,
       detail: message,
       closable: true,
@@ -53,6 +53,16 @@ export class NotificationService {
       detail: message,
       closable: true,
       sticky: false,
+    });
+  }
+
+  showWarningMessage(message: string) {
+    this.messageService.add({
+      severity: 'warn',
+      summary: $localize`Warning`,
+      detail: message,
+      closable: true,
+      sticky: true,
     });
   }
 

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -12,7 +12,7 @@ export class NotificationService {
    * This message is sticky and closable.
    * @param message
    */
-  showErrorMessage(message: string) {
+  showErrorMessage(message: string): void {
     this.messageService.add({
       severity: 'error',
       summary: $localize`Error`,
@@ -28,7 +28,7 @@ export class NotificationService {
    * @param title
    * @param message
    */
-  showErrorMessageWithTitle(title: string, message: string) {
+  showErrorMessageWithTitle(title: string, message: string): void {
     this.messageService.add({
       severity: 'error',
       summary: title,
@@ -46,7 +46,7 @@ export class NotificationService {
    * e.g. when editing a list item showing the updated list.
    * @param message
    */
-  showSuccessMessage(message: string) {
+  showSuccessMessage(message: string): void {
     this.messageService.add({
       severity: 'success',
       summary: $localize`Success`,
@@ -61,7 +61,7 @@ export class NotificationService {
    * The message is sticky and closable.
    * @param message
    */
-  showWarningMessage(message: string) {
+  showWarningMessage(message: string): void {
     this.messageService.add({
       severity: 'warn',
       summary: $localize`Warning`,
@@ -78,7 +78,7 @@ export class NotificationService {
    * @param title
    * @param message
    */
-  showInfoMessage(title: string, message: string) {
+  showInfoMessage(title: string, message: string): void {
     this.messageService.add({
       severity: 'info',
       summary: title,

--- a/src/app/invitations/invitation-form/invitation-form.component.ts
+++ b/src/app/invitations/invitation-form/invitation-form.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core
 import { Organization } from '../../types/organization';
 import { BillingEntity } from '../../types/billing-entity';
 import { InvitationCollectionService } from '../../store/invitation-collection.service';
-import { MessageService } from 'primeng/api';
 import { Invitation, TargetRef } from '../../types/invitation';
 import { v4 as uuidv4 } from 'uuid';
 import { faClose, faGift } from '@fortawesome/free-solid-svg-icons';
@@ -193,7 +192,7 @@ export class InvitationFormComponent implements OnInit {
         this.notificationService.showSuccessMessage($localize`Invitation successfully saved`);
         void this.router.navigate([this.navigationService.previousLocation('..')], { relativeTo: this.activatedRoute });
       },
-      error: (err) => {
+      error: () => {
         this.notificationService.showErrorMessage($localize`Invitation could not be saved. Please try again later.`);
       },
     });

--- a/src/app/invitations/invitation-form/invitation-form.component.ts
+++ b/src/app/invitations/invitation-form/invitation-form.component.ts
@@ -33,6 +33,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { NgIf, NgFor } from '@angular/common';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { InputTextModule } from 'primeng/inputtext';
+import { NotificationService } from '../../core/notification.service';
 
 @Component({
   selector: 'app-invitation-form',
@@ -77,11 +78,11 @@ export class InvitationFormComponent implements OnInit {
 
   constructor(
     public invitationService: InvitationCollectionService,
-    private messageService: MessageService,
     private formBuilder: FormBuilder,
     private router: Router,
     private activatedRoute: ActivatedRoute,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -189,18 +190,11 @@ export class InvitationFormComponent implements OnInit {
     invitation.spec.targetRefs = targetRefs;
     this.invitationService.add(invitation).subscribe({
       next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Invitation successfully saved',
-        });
+        this.notificationService.showSuccessMessage($localize`Invitation successfully saved`);
         void this.router.navigate([this.navigationService.previousLocation('..')], { relativeTo: this.activatedRoute });
       },
       error: (err) => {
-        this.messageService.add({
-          severity: 'error',
-          summary: err.message,
-          sticky: true,
-        });
+        this.notificationService.showErrorMessage($localize`Invitation could not be saved. Please try again later.`);
       },
     });
   }

--- a/src/app/invitations/invitation-view/invitation-view.component.html
+++ b/src/app/invitations/invitation-view/invitation-view.component.html
@@ -2,6 +2,10 @@
   <h1 class="pt-0 mt-0 mb-0" i18n id="title">Invitation</h1>
 </div>
 
+<div *ngIf="redeemSuccessMessage" class="mb-2">
+  <p-message [text]="redeemSuccessMessage" severity="success"></p-message>
+</div>
+
 <ng-container *ngrxLet="payload$ as payload; suspenseTpl: loading; error as err">
   <ng-container *ngIf="payload">
     <p-messages *ngIf="payload.isRedeemed" severity="warn">

--- a/src/app/invitations/invitation-view/invitation-view.component.html
+++ b/src/app/invitations/invitation-view/invitation-view.component.html
@@ -2,10 +2,6 @@
   <h1 class="pt-0 mt-0 mb-0" i18n id="title">Invitation</h1>
 </div>
 
-<div *ngIf="redeemSuccessMessage" class="mb-2">
-  <p-message [text]="redeemSuccessMessage" severity="success"></p-message>
-</div>
-
 <ng-container *ngrxLet="payload$ as payload; suspenseTpl: loading; error as err">
   <ng-container *ngIf="payload">
     <p-messages *ngIf="payload.isRedeemed" severity="warn">

--- a/src/app/invitations/invitation-view/invitation-view.component.ts
+++ b/src/app/invitations/invitation-view/invitation-view.component.ts
@@ -5,7 +5,7 @@ import { InvitationCollectionService } from '../../store/invitation-collection.s
 import { Invitation, invitationTokenLocalStorageKey } from '../../types/invitation';
 import { faInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { InvitationRedeemRequestCollectionService } from '../../store/invitation-redeem-request-collection.service';
-import { MessageService, SharedModule } from 'primeng/api';
+import { SharedModule } from 'primeng/api';
 import { DataServiceError } from '@ngrx/data';
 import { OrganizationCollectionService } from '../../store/organization-collection.service';
 import { BillingEntityCollectionService } from '../../store/billingentity-collection.service';
@@ -43,8 +43,6 @@ export class InvitationViewComponent implements OnInit {
 
   faWarning = faWarning;
   faInfo = faInfo;
-
-  redeemSuccessMessage?: string;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -158,19 +156,24 @@ export class InvitationViewComponent implements OnInit {
   }
 
   addErrorNotification(err: DataServiceError | Error): void {
-    let message = $localize`Redeem failed`;
     if (err instanceof DataServiceError && err.error.status === 403) {
-      message = $localize`Not allowed, most likely already redeemed`;
+      this.notificationService.showErrorMessageWithTitle(
+        $localize`Redeem failed`,
+        $localize`Not allowed, most likely already redeemed`
+      );
+    } else {
+      this.notificationService.showErrorMessage($localize`Redeem failed`);
     }
-    this.notificationService.showErrorMessage(message);
   }
 
   private checkInvitation(invitation: Invitation): void {
     if (this.allTargetsReady(invitation)) {
-      this.redeemSuccessMessage = $localize`Invitation accepted.`;
+      this.notificationService.showSuccessMessage($localize`Invitation accepted.`);
     }
     if (this.someTargetsFailed(invitation)) {
-      this.redeemSuccessMessage = $localize`Invitation accepted, though not all permissions could be granted.`;
+      this.notificationService.showWarningMessage(
+        $localize`Invitation accepted, though not all permissions could be granted.`
+      );
     }
     this.billingService.resetMemoization();
     this.organizationService.resetMemoization();

--- a/src/app/invitations/invitation-view/invitation-view.component.ts
+++ b/src/app/invitations/invitation-view/invitation-view.component.ts
@@ -67,8 +67,8 @@ export class InvitationViewComponent implements OnInit {
     const storageAvailable = this.storageService.storageAvailable('localStorage');
     if (!storageAvailable) {
       this.notificationService.showErrorMessageWithTitle(
-        $localize`Local storage not available in your browser.`,
-        $localize`Local storage is required for redeeming invitations.`
+        $localize`Local storage not available.`,
+        $localize`Enable local storage in your browser to redeem invitations.`
       );
     }
     const tokenInQuery = this.activatedRoute.snapshot.queryParamMap.get('token');

--- a/src/app/kubernetes-permission.guard.ts
+++ b/src/app/kubernetes-permission.guard.ts
@@ -3,7 +3,6 @@ import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot } fr
 import { catchError, forkJoin, map, of, tap } from 'rxjs';
 import { SelfSubjectAccessReviewCollectionService } from './store/ssar-collection.service';
 import { SelfSubjectAccessReviewAttributes } from './types/self-subject-access-review';
-import { DataServiceError } from '@ngrx/data';
 import { NotificationService } from './core/notification.service';
 
 /**
@@ -32,7 +31,7 @@ export const KubernetesPermissionGuard: CanActivateFn = (
         void router.navigate(['/home']);
       }
     }),
-    catchError((err: DataServiceError) => {
+    catchError(() => {
       notificationService.showErrorMessage($localize`Server unavailable. Please try again in a few minutes.`);
       void router.navigate(['/home']);
       return of(false);

--- a/src/app/kubernetes-permission.guard.ts
+++ b/src/app/kubernetes-permission.guard.ts
@@ -4,7 +4,7 @@ import { catchError, forkJoin, map, of, tap } from 'rxjs';
 import { SelfSubjectAccessReviewCollectionService } from './store/ssar-collection.service';
 import { SelfSubjectAccessReviewAttributes } from './types/self-subject-access-review';
 import { DataServiceError } from '@ngrx/data';
-import { MessageService } from 'primeng/api';
+import { NotificationService } from './core/notification.service';
 
 /**
  * This is a backed with @ngrx/data, intended to be replacing it over time.
@@ -22,7 +22,7 @@ export const KubernetesPermissionGuard: CanActivateFn = (
     permissionService.isAllowed(attr.group, attr.resource, attr.verb, attr.namespace)
   );
   const router: Router = inject(Router);
-  const messageService: MessageService = inject(MessageService);
+  const notificationService: NotificationService = inject(NotificationService);
   return forkJoin(permissionList$).pipe(
     map((perms: boolean[]) => {
       return perms.every((allowed) => allowed);
@@ -33,11 +33,7 @@ export const KubernetesPermissionGuard: CanActivateFn = (
       }
     }),
     catchError((err: DataServiceError) => {
-      messageService.add({
-        severity: 'error',
-        summary: $localize`Could not determine access permissions`,
-        detail: err.message ?? undefined,
-      });
+      notificationService.showErrorMessage($localize`Server unavailable. Please try again in a few minutes.`);
       void router.navigate(['/home']);
       return of(false);
     })

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, FormControl, FormGroup, Validators, ReactiveFormsModule } 
 import { faSave } from '@fortawesome/free-solid-svg-icons';
 import { Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { MessageService, SelectItem } from 'primeng/api';
+import { SelectItem } from 'primeng/api';
 import { OrganizationNameService } from '../organization-name.service';
 import { OrganizationCollectionService } from '../../store/organization-collection.service';
 import { BillingEntity } from '../../types/billing-entity';

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -171,8 +171,7 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
   }
 
   private saveOrUpdateFailure(err: DataServiceError): void {
-    let message = $localize`Could not save organization '${this.form.get('organizationId')
-      ?.value}'. Please try again later.`;
+    let message = $localize`Could not save organization '${this.form.get('organizationId')?.value}'.`;
     if (409 === err.error?.status || err.message?.includes('already exists')) {
       this.form.get('organizationId')?.setErrors({ alreadyExists: true });
       message = $localize`Organization "${this.form.get('organizationId')?.value}" already exists.`;

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -17,6 +17,8 @@ import { DropdownModule } from 'primeng/dropdown';
 import { MessageModule } from 'primeng/message';
 import { NgIf } from '@angular/common';
 import { InputTextModule } from 'primeng/inputtext';
+import { NotificationService } from '../../core/notification.service';
+import { DataServiceError } from '@ngrx/data';
 
 @Component({
   selector: 'app-organization-form',
@@ -55,16 +57,16 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
   billingOptions: SelectItem<BillingEntity>[] = [];
 
   faSave = faSave;
-  private subscriptions: Subscription[] = [];
+  subscriptions: Subscription[] = [];
 
   constructor(
     private formBuilder: FormBuilder,
     private router: Router,
     private activatedRoute: ActivatedRoute,
-    private messageService: MessageService,
     private organizationNameService: OrganizationNameService,
     public organizationCollectionService: OrganizationCollectionService,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -153,10 +155,9 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
   }
 
   private saveOrUpdateSuccess(): void {
-    this.messageService.add({
-      severity: 'success',
-      summary: $localize`Successfully saved`,
-    });
+    this.notificationService.showSuccessMessage(
+      $localize`Successfully saved organization '${this.form.getRawValue().displayName}'.`
+    );
     const firstTime = this.activatedRoute.snapshot.queryParamMap.get('firstTime') === 'y';
     if (firstTime) {
       void this.router.navigate(['zones'], {
@@ -169,22 +170,13 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
     void this.router.navigate([previous.path], { relativeTo: this.activatedRoute, queryParams: previous.queryParams });
   }
 
-  private saveOrUpdateFailure(err: Error): void {
-    let detail = '';
-    if ('message' in err) {
-      detail = err.message;
+  private saveOrUpdateFailure(err: DataServiceError): void {
+    let message = $localize`Could not save organization '${this.form.get('organizationId')
+      ?.value}'. Please try again later.`;
+    if (409 === err.error?.status || err.message?.includes('already exists')) {
+      this.form.get('organizationId')?.setErrors({ alreadyExists: true });
+      message = $localize`Organization "${this.form.get('organizationId')?.value}" already exists.`;
     }
-    if ('reason' in err) {
-      if ('AlreadyExists' === err.reason) {
-        this.form.get('organizationId')?.setErrors({ alreadyExists: true });
-        detail = $localize`Organization "${this.form.get('organizationId')?.value}" already exists.`;
-      }
-    }
-    this.messageService.add({
-      severity: 'error',
-      summary: $localize`Error`,
-      sticky: true,
-      detail,
-    });
+    this.notificationService.showErrorMessage(message);
   }
 }

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -19,6 +19,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
+import { NotificationService } from '../../core/notification.service';
 
 interface Payload {
   members: OrganizationMembers;
@@ -71,11 +72,11 @@ export class OrganizationMembersEditComponent implements OnInit {
 
   constructor(
     private activatedRoute: ActivatedRoute,
-    private messageService: MessageService,
     private router: Router,
     private membersService: OrganizationMembersCollectionService,
     private rolebindingService: RolebindingCollectionService,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private notificationService: NotificationService
   ) {}
 
   get userRefs(): FormArray | undefined {
@@ -129,6 +130,7 @@ export class OrganizationMembersEditComponent implements OnInit {
       this.addEmptyFormControl();
     }
   }
+
   addEmptyFormControl(): void {
     const emptyFormControl = new FormControl();
     emptyFormControl.valueChanges.pipe(take(1)).subscribe(() => {
@@ -189,18 +191,13 @@ export class OrganizationMembersEditComponent implements OnInit {
       ),
     ]).subscribe({
       next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: $localize`Successfully saved`,
-        });
+        this.notificationService.showSuccessMessage(
+          $localize`Successfully saved changes to '${payload.members.metadata.namespace}'.`
+        );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: (error) => {
-        this.messageService.add({
-          severity: 'error',
-          summary: $localize`Error`,
-          detail: error.message,
-        });
+        this.notificationService.showErrorMessage($localize`Could not save changes. Please try again later.`);
       },
     });
   }

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -4,7 +4,7 @@ import { faClose, faSave, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { OrganizationMembers } from '../../types/organization-members';
 import { FormArray, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { combineLatestWith, forkJoin, map, Observable, take } from 'rxjs';
-import { MessageService, SharedModule } from 'primeng/api';
+import { SharedModule } from 'primeng/api';
 import { RoleBinding } from 'src/app/types/role-binding';
 import { OrganizationMembersCollectionService } from '../../store/organizationmembers-collection.service';
 import { RolebindingCollectionService } from '../../store/rolebinding-collection.service';
@@ -196,7 +196,7 @@ export class OrganizationMembersEditComponent implements OnInit {
         );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
-      error: (error) => {
+      error: () => {
         this.notificationService.showErrorMessage($localize`Could not save changes. Please try again later.`);
       },
     });

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -185,7 +185,11 @@ export class OrganizationMembersEditComponent implements OnInit {
           metadata: { ...roleBinding.metadata },
           roleRef: { ...roleBinding.roleRef },
           subjects: rolesToSubjects[roleBinding.roleRef.name].map((sub) => {
-            return { apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: `${this.userNamePrefix}${sub}` };
+            return {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'User',
+              name: `${this.userNamePrefix}${sub}`,
+            };
           }),
         })
       ),
@@ -197,7 +201,7 @@ export class OrganizationMembersEditComponent implements OnInit {
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: () => {
-        this.notificationService.showErrorMessage($localize`Could not save changes. Please try again later.`);
+        this.notificationService.showErrorMessage($localize`Could not save changes.`);
       },
     });
   }

--- a/src/app/teams/team-edit/team-edit.component.ts
+++ b/src/app/teams/team-edit/team-edit.component.ts
@@ -99,7 +99,7 @@ export class TeamEditComponent implements OnInit {
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: (error) => {
-        let message = $localize`Could not save team '${this.form.get('name')?.value}'. Please try again later.`;
+        let message = $localize`Could not save team '${this.form.get('name')?.value}'. `;
         if (409 === error.error.status || error.message?.includes('already exists')) {
           this.form.get('name')?.setErrors({ alreadyExists: true });
           message = $localize`Team '${this.form.get('name')?.value}' already exists.`;

--- a/src/app/teams/team-edit/team-edit.component.ts
+++ b/src/app/teams/team-edit/team-edit.component.ts
@@ -3,7 +3,7 @@ import { faClose, faSave, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { Team } from '../../types/team';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { MessageService, SharedModule } from 'primeng/api';
+import { SharedModule } from 'primeng/api';
 import { Observable, of, take, tap } from 'rxjs';
 import { TeamCollectionService } from '../../store/team-collection.service';
 import { NavigationService } from '../../shared/navigation.service';
@@ -16,6 +16,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
+import { NotificationService } from '../../core/notification.service';
 
 @Component({
   selector: 'app-team-edit',
@@ -51,9 +52,9 @@ export class TeamEditComponent implements OnInit {
     private formBuilder: FormBuilder,
     private router: Router,
     private activatedRoute: ActivatedRoute,
-    private messageService: MessageService,
     public teamService: TeamCollectionService,
-    private navigationService: NavigationService
+    private navigationService: NavigationService,
+    private notificationService: NotificationService
   ) {}
 
   get userRefs(): FormArray {
@@ -94,27 +95,16 @@ export class TeamEditComponent implements OnInit {
     team = this.getTeamFromForm(team);
     (this.new ? this.teamService.add(team) : this.teamService.update(team)).subscribe({
       next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: $localize`Successfully saved`,
-        });
+        this.notificationService.showSuccessMessage($localize`Team "${team.metadata.name}" saved.`);
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: (error) => {
-        let detail = '';
-        if ('message' in error.error) {
-          detail = error.error.message;
-        }
-        if ('AlreadyExists' === error.error.reason) {
+        let message = $localize`Could not save team '${this.form.get('name')?.value}'. Please try again later.`;
+        if (409 === error.error.status || error.message?.includes('already exists')) {
           this.form.get('name')?.setErrors({ alreadyExists: true });
-          detail = $localize`Team "${this.form.get('name')?.value}" already exists.`;
+          message = $localize`Team '${this.form.get('name')?.value}' already exists.`;
         }
-        this.messageService.add({
-          severity: 'error',
-          summary: $localize`Error`,
-          detail,
-          sticky: true,
-        });
+        this.notificationService.showErrorMessage(message);
       },
     });
   }

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { selectQueryParam } from '../store/router.selectors';
 import { Team } from '../types/team';
 import { JoinTeamDialogComponent } from './join-team-dialog/join-team-dialog.component';
-import { ConfirmationService, MessageService, SharedModule } from 'primeng/api';
+import { ConfirmationService, SharedModule } from 'primeng/api';
 import { OrganizationCollectionService } from '../store/organization-collection.service';
 import { TeamCollectionService } from '../store/team-collection.service';
 import { Organization } from '../types/organization';

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -18,6 +18,7 @@ import { RippleModule } from 'primeng/ripple';
 import { ButtonModule } from 'primeng/button';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
+import { NotificationService } from '../core/notification.service';
 
 interface Payload {
   organization?: Organization;
@@ -64,7 +65,7 @@ export class TeamsComponent implements OnInit, OnDestroy {
     private confirmationService: ConfirmationService,
     private organizationService: OrganizationCollectionService,
     private teamService: TeamCollectionService,
-    private messageService: MessageService,
+    private notificationService: NotificationService,
     private changeDetectorRef: ChangeDetectorRef
   ) {}
 
@@ -139,29 +140,22 @@ export class TeamsComponent implements OnInit, OnDestroy {
   }
 
   deleteTeam(team: Team): void {
+    const teamName = team.spec.displayName || team.metadata.name;
     this.confirmationService.confirm({
       header: 'Delete team',
-      message: $localize`Are you sure that you want to delete the team '${team.spec.displayName}'?`,
+      message: $localize`Are you sure that you want to delete the team '${teamName}'?`,
       icon: 'pi pi-exclamation-triangle',
       accept: () => {
         this.subscriptions.push(
           this.teamService.delete(team).subscribe({
             next: (name) => {
-              this.messageService.add({
-                severity: 'success',
-                summary: $localize`Successfully deleted team ${name}`,
-              });
+              this.notificationService.showSuccessMessage($localize`Successfully deleted team '${name}'`);
               // After deleting, ensure that the displayed list doesn't contain the deleted element anymore.
               this.subscribePayloads();
               this.changeDetectorRef.markForCheck();
             },
-            error: (err: Error) => {
-              this.messageService.add({
-                severity: 'error',
-                summary: $localize`Error`,
-                detail: err.message,
-                sticky: true,
-              });
+            error: () => {
+              this.notificationService.showErrorMessage($localize`Could not delete team '${teamName}'. `);
               this.subscribePayloads();
               this.changeDetectorRef.markForCheck();
             },

--- a/src/app/user/user-edit/user-edit.component.ts
+++ b/src/app/user/user-edit/user-edit.component.ts
@@ -19,6 +19,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { MessageModule } from 'primeng/message';
 import { NgIf } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
+import { NotificationService } from '../../core/notification.service';
 
 @Component({
   selector: 'app-user-edit',
@@ -55,7 +56,7 @@ export class UserEditComponent implements OnInit {
     private organizationService: OrganizationCollectionService,
     private orgMembersService: OrganizationMembersCollectionService,
     public userService: UserCollectionService,
-    private messageService: MessageService
+    private notificationService: NotificationService
   ) {}
 
   ngOnInit(): void {
@@ -120,18 +121,10 @@ export class UserEditComponent implements OnInit {
     };
     this.userService.update(clone).subscribe({
       next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: $localize`Successfully saved`,
-        });
+        this.notificationService.showSuccessMessage($localize`Saved successfully`);
       },
       error: (err) => {
-        this.messageService.add({
-          severity: 'error',
-          summary: $localize`Error`,
-          detail: err.message,
-          sticky: true,
-        });
+        this.notificationService.showErrorMessage($localize`Could not save user preferences. Please try again later.`);
       },
     });
   }

--- a/src/app/user/user-edit/user-edit.component.ts
+++ b/src/app/user/user-edit/user-edit.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { catchError, combineLatestWith, forkJoin, map, Observable, of } from 'rxjs';
-import { MessageService, SelectItem, SharedModule } from 'primeng/api';
+import { SelectItem, SharedModule } from 'primeng/api';
 import { faSave, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { Organization } from '../../types/organization';
 import { IdentityService } from '../../core/identity.service';
@@ -123,7 +123,7 @@ export class UserEditComponent implements OnInit {
       next: () => {
         this.notificationService.showSuccessMessage($localize`Saved successfully`);
       },
-      error: (err) => {
+      error: () => {
         this.notificationService.showErrorMessage($localize`Could not save user preferences. Please try again later.`);
       },
     });

--- a/src/app/user/user-edit/user-edit.component.ts
+++ b/src/app/user/user-edit/user-edit.component.ts
@@ -124,7 +124,7 @@ export class UserEditComponent implements OnInit {
         this.notificationService.showSuccessMessage($localize`Saved successfully`);
       },
       error: () => {
-        this.notificationService.showErrorMessage($localize`Could not save user preferences. Please try again later.`);
+        this.notificationService.showErrorMessage($localize`Could not save user preferences.`);
       },
     });
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -52,6 +52,12 @@ body {
   flex-shrink: 0;
 }
 
+.p-toast-message-icon {
+  timescircleicon {
+    display: none;
+  }
+}
+
 .p-divider.p-divider-horizontal {
   padding: 0;
   margin-bottom: 0.625rem;


### PR DESCRIPTION
## Summary

Makes the notification behavior consistent.

Closes https://github.com/appuio/cloud-portal/issues/542

## Details

- All error toast messages are sticky, so the user has enough time to read / screenshot them
- Slightly changed wording of error message, so they are not too technical, and if relevant, gives the user a hint what they can do to resolve it (e.g. enable local storage)
- No technical error details (such as urls, port) are shown to the user
- All toasts can be dismissed by the user
- Success messages disappear automatically (i.e. disappear automatically after a few seconds)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.


