### PR TITLE
Use display name as title

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
         printLogsToConsole: 'always',
       });
     },
+    experimentalRunAllSpecs: true,
   },
 });

--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -21,8 +21,8 @@ describe('Test billing entity list', () => {
     cy.visit('/billingentities');
     cy.get('#billingentities-title').should('contain.text', 'Billing');
     cy.get('#addButton').should('contain.text', 'Add new Billing');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', '➡️ Engineering GmbH');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', '👁️ AG');
   });
 
   it('empty list', () => {
@@ -54,8 +54,8 @@ describe('Test billing entity list', () => {
     cy.visit('/billingentities');
 
     cy.get('#billingentities-title').should('contain.text', 'Billing');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'be-2345');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'be-2347');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', '➡️ Engineering GmbH');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', '👁️ AG');
   });
 });
 
@@ -132,10 +132,11 @@ describe('Test billing entity details', () => {
     });
     cy.visit('/billingentities/be-2345');
     cy.get('.flex-wrap > .text-900').eq(0).should('contain.text', '➡️ Engineering GmbH');
-    cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'hallo@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', '☎️');
-    cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '📃📋🏤 🏙️Switzerland');
-    cy.get('.flex-wrap > .text-900').eq(4).should('contain.text', 'mig hallo@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', '🇩🇪');
+    cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'be-2345');
+    cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', 'hallo@nxt.engineering');
+    cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '☎️');
+    cy.get('.flex-wrap > .text-900').eq(4).should('contain.text', '📃📋🏤 🏙️Switzerland');
+    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', 'mig hallo@nxt.engineering');
+    cy.get('.flex-wrap > .text-900').eq(6).should('contain.text', '🇩🇪');
   });
 });

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -194,7 +194,7 @@ describe('Test billing entity create', () => {
     );
   });
 
-  it('should create billing', () => {
+  it.only('should create billing', () => {
     cy.intercept('POST', '/appuio-api/apis/billing.appuio.io/v1/billingentities', {
       body: billingEntityNxt,
     }).as('createBillingEntity');
@@ -245,7 +245,7 @@ describe('Test billing entity create', () => {
     cy.url().should('include', '/billingentities/be-2345').should('not.include', '?edit=y');
     cy.get('.flex-wrap > .text-900').eq(0).should('contain.text', '➡️ Engineering GmbH');
 
-    cy.get('#title').should('contain.text', 'be-2345');
+    cy.get('#title').should('contain.text', '➡️ Engineering GmbH');
     cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'be-2345');
     cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', 'hallo@nxt.engineering');
     cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '☎️');

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -245,12 +245,13 @@ describe('Test billing entity create', () => {
     cy.url().should('include', '/billingentities/be-2345').should('not.include', '?edit=y');
     cy.get('.flex-wrap > .text-900').eq(0).should('contain.text', '➡️ Engineering GmbH');
 
-    cy.get('#title').should('contain.text', 'be-2345');
-    cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'hallo@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', '☎️');
-    cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '📃📋🏤 🏙️Switzerland');
-    cy.get('.flex-wrap > .text-900').eq(4).should('contain.text', 'mig hallo@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', '🇩🇪');
+    cy.get('#title').should('contain.text', '➡️ Engineering GmbH');
+    cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'be-2345');
+    cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', 'hallo@nxt.engineering');
+    cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '☎️');
+    cy.get('.flex-wrap > .text-900').eq(4).should('contain.text', '📃📋🏤 🏙️Switzerland');
+    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', 'mig hallo@nxt.engineering');
+    cy.get('.flex-wrap > .text-900').eq(6).should('contain.text', '🇩🇪');
   });
 
   it('should forward to organizations if first time', () => {
@@ -315,7 +316,7 @@ describe('Test billing entity edit', () => {
     }).as('updateBillingEntity');
 
     cy.visit('/billingentities/be-2345');
-    cy.get('#title').should('contain.text', 'be-2345');
+    cy.get('#title').should('contain.text', '➡️ Engineering GmbH');
 
     cy.get('svg[class*="fa-pen-to-square"]').click();
 
@@ -364,19 +365,20 @@ describe('Test billing entity edit', () => {
     cy.get('p-toast').should('contain.text', 'Successfully saved');
     cy.url().should('include', '/billingentities/be-2345').should('not.include', '?edit=y');
     // check values
-    cy.get('#title').should('contain.text', 'be-2345');
+    cy.get('#title').should('contain.text', 'nxt Engineering');
     cy.get('.flex-wrap > .text-900').eq(0).should('contain.text', 'nxt Engineering');
+    cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'be-2345');
     cy.get('.flex-wrap > .text-900')
-      .eq(1)
+      .eq(2)
       .should('contain.text', 'hallo@nxt.engineering')
       .should('contain.text', 'info@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', '1234');
+    cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '1234');
     cy.get('.flex-wrap > .text-900')
-      .eq(3)
+      .eq(4)
       .should('contain.text', 'line1')
       .should('contain.text', '4321 Berlin')
       .should('contain.text', 'Germany');
-    cy.get('.flex-wrap > .text-900').eq(4).should('contain.text', 'crc hallo@nxt.engineering');
-    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', '🇩🇪');
+    cy.get('.flex-wrap > .text-900').eq(5).should('contain.text', 'crc hallo@nxt.engineering');
+    cy.get('.flex-wrap > .text-900').eq(6).should('contain.text', '🇩🇪');
   });
 });

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -245,7 +245,7 @@ describe('Test billing entity create', () => {
     cy.url().should('include', '/billingentities/be-2345').should('not.include', '?edit=y');
     cy.get('.flex-wrap > .text-900').eq(0).should('contain.text', '➡️ Engineering GmbH');
 
-    cy.get('#title').should('contain.text', '➡️ Engineering GmbH');
+    cy.get('#title').should('contain.text', 'be-2345');
     cy.get('.flex-wrap > .text-900').eq(1).should('contain.text', 'be-2345');
     cy.get('.flex-wrap > .text-900').eq(2).should('contain.text', 'hallo@nxt.engineering');
     cy.get('.flex-wrap > .text-900').eq(3).should('contain.text', '☎️');

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -194,7 +194,7 @@ describe('Test billing entity create', () => {
     );
   });
 
-  it.only('should create billing', () => {
+  it('should create billing', () => {
     cy.intercept('POST', '/appuio-api/apis/billing.appuio.io/v1/billingentities', {
       body: billingEntityNxt,
     }).as('createBillingEntity');

--- a/cypress/e2e/billingentity-members.cy.ts
+++ b/cypress/e2e/billingentity-members.cy.ts
@@ -75,7 +75,7 @@ describe('billing entity edit members with existing roles', () => {
     ).as('updateAdmin');
 
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     cy.get('[data-cy="name-input-1"]').type('crc');
     cy.get('p-multiselect').eq(1).click().contains('billingentities-be-2345-admin').click();
     cy.get('button[type=submit]').click();
@@ -139,7 +139,7 @@ describe('billing entity edit members with existing roles', () => {
     ).as('updateAdmin');
 
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     cy.get('button[title="Remove"]').eq(1).click();
     cy.get('button[type=submit]').click();
     cy.wait('@updateViewer');
@@ -188,7 +188,7 @@ describe('billing entity edit members with existing roles', () => {
     );
 
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     cy.get('button[title="Remove"]').eq(0).click();
     cy.get('p-message').contains('You are about to remove yourself as admin!');
   });
@@ -239,7 +239,7 @@ describe('billing entity edit members with existing roles', () => {
     ).as('updateAdmin');
 
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     const multiSelect = cy.get('p-multiselect').eq(1);
     multiSelect.click();
     multiSelect.get('p-multiselectitem').contains('billingentities-be-2345-admin').click();
@@ -283,7 +283,7 @@ describe('billing entity edit members with existing roles', () => {
       }
     );
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     const multiSelect = cy.get('p-multiselect').eq(0);
     multiSelect.click();
     multiSelect.get('p-multiselectitem').contains('billingentities-be-2345-admin').click();
@@ -370,7 +370,7 @@ describe('billing entity edit members without initial roles', () => {
     }).as('createRoleBinding');
 
     cy.visit('/billingentities/be-2345/members');
-    cy.get('.text-3xl').should('contain.text', 'be-2345 Members');
+    cy.get('.text-3xl').should('contain.text', '➡️ Engineering GmbH Members');
     cy.get('[data-cy="name-input-0"]').type('crc');
     cy.get('p-multiselect').eq(0).click().contains('billingentities-be-2345-admin').click();
     cy.get('button[type=submit]').click();

--- a/cypress/e2e/invitations-accept.cy.ts
+++ b/cypress/e2e/invitations-accept.cy.ts
@@ -229,7 +229,7 @@ describe('Test invitation accept for existing user', () => {
     ).as('getInvitation');
 
     cy.visit('/organizations');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
 
     cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
     cy.wait('@createInvitationRedeemRequest');
@@ -239,8 +239,8 @@ describe('Test invitation accept for existing user', () => {
     cy.get('p-toast').should('contain.text', 'Invitation accepted');
 
     cy.get('app-navbar-item').contains('Organizations').click();
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'vshn');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'nxt');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering GmbH');
   });
 
   it('should display message even if navigated away', () => {
@@ -285,7 +285,7 @@ describe('Test invitation accept for existing user', () => {
     cy.get('#title').should('contain.text', 'Invitation');
 
     cy.get('app-navbar-item').contains('Organizations').click();
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering GmbH');
     cy.get('p-toast', { timeout: 10000 }).should('contain.text', 'Invitation accepted');
   });
 });

--- a/cypress/e2e/organization-form.cy.ts
+++ b/cypress/e2e/organization-form.cy.ts
@@ -60,7 +60,7 @@ describe('Test organization add', () => {
         expect(body.spec.displayName).to.eq('VSHN - the DevOps Company');
         expect(body.spec.billingEntityRef).to.eq('be-2347');
       });
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
     cy.get(':nth-child(3) > .border-top-1 > .list-none > .flex > .text-900').should(
       'contain.text',
       'VSHN - the DevOps Company'
@@ -196,12 +196,12 @@ describe('Test organization edit', () => {
       'contain.text',
       'nxt Engineering GmbH'
     );
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'VSHN AG');
     cy.get(':nth-child(3) > .border-top-1 > .list-none > .flex > .text-900').should('contain.text', 'VSHN AG');
 
     cy.get(':nth-child(2) > .flex-row [title="Edit organization"]').should('not.exist');
     cy.get(':nth-child(3) > .flex-row [title="Edit organization"]').click();
-    cy.get('.text-3xl').should('contain.text', 'vshn');
+    cy.get('#title').should('contain.text', 'VSHN AG');
     cy.get('#selectedBillingEntity').should('contain.text', '👁️ AG');
     cy.get('#displayName').type('{selectall}');
     cy.get('#displayName').type('VSHN - the DevOps Company');
@@ -215,12 +215,12 @@ describe('Test organization edit', () => {
         expect(body.spec.displayName).to.eq('VSHN - the DevOps Company');
         expect(body.spec.billingEntityRef).to.eq('be-2345');
       });
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering GmbH');
     cy.get(':nth-child(2) > .border-top-1 > .list-none > .flex > .text-900').should(
       'contain.text',
       'nxt Engineering GmbH'
     );
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
     cy.get(':nth-child(3) > .border-top-1 > .list-none > .flex > .text-900').should(
       'contain.text',
       'VSHN - the DevOps Company'

--- a/cypress/e2e/organization-form.cy.ts
+++ b/cypress/e2e/organization-form.cy.ts
@@ -201,7 +201,7 @@ describe('Test organization edit', () => {
 
     cy.get(':nth-child(2) > .flex-row [title="Edit organization"]').should('not.exist');
     cy.get(':nth-child(3) > .flex-row [title="Edit organization"]').click();
-    cy.get('#title').should('contain.text', 'VSHN AG');
+    cy.get('#title').should('contain.text', 'vshn');
     cy.get('#selectedBillingEntity').should('contain.text', '👁️ AG');
     cy.get('#displayName').type('{selectall}');
     cy.get('#displayName').type('VSHN - the DevOps Company');

--- a/cypress/e2e/organization-members.cy.ts
+++ b/cypress/e2e/organization-members.cy.ts
@@ -48,7 +48,7 @@ describe('Test organization members', () => {
     cy.visit('/organizations');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
-    cy.get('.text-3xl').should('contain.text', 'nxt Members');
+    cy.get('.text-3xl').should('contain.text', 'nxt Engineering GmbH Members');
     cy.get('[data-cy="name-input-0"]').should('have.value', 'hans.meier').and('be.disabled');
     cy.get('[data-cy="name-input-1"]').should('have.value', 'peter.muster').and('be.disabled');
     cy.get(':nth-child(2) .p-multiselect')
@@ -112,7 +112,7 @@ describe('Test organization members', () => {
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').should('exist');
     cy.get(':nth-child(3) > .flex-row [title="Edit members"]').should('not.exist');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
-    cy.get('.text-3xl').should('contain.text', 'nxt Members');
+    cy.get('.text-3xl').should('contain.text', 'nxt Engineering GmbH Members');
     cy.get('[data-cy="name-input-0"]').should('have.value', 'hans.meier');
     cy.get('[data-cy="name-input-1"]').should('have.value', 'peter.muster');
     cy.get('[data-cy="name-input-1"]').type('{selectall}test');
@@ -190,7 +190,7 @@ describe('Test organization members', () => {
     cy.visit('/organizations');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
     cy.get(':nth-child(2) > .flex-row [title="Edit members"]').click();
-    cy.get('.text-3xl').should('contain.text', 'nxt Members');
+    cy.get('.text-3xl').should('contain.text', 'nxt Engineering GmbH Members');
     cy.get('[data-cy="name-input-0"]').first().should('have.value', 'hans.meier');
     cy.get('[data-cy="name-input-1"]').should('have.value', 'peter.muster');
     cy.get('[data-cy="name-input-2"]').type('{selectall}test');

--- a/cypress/e2e/organizations.cy.ts
+++ b/cypress/e2e/organizations.cy.ts
@@ -28,8 +28,8 @@ describe('Test organization list', () => {
     setOrganization(cy, ...organizationListNxtVshn.items);
     cy.visit('/organizations');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering GmbH');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
   });
 
   it('list with edit permissions', () => {
@@ -43,7 +43,7 @@ describe('Test organization list', () => {
     setOrganization(cy, createOrganization({ name: 'nxt', displayName: 'nxt Engineering', billingRef: 'be-2345' }));
     cy.visit('/organizations');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering');
     cy.get('svg[class*="fa-pen-to-square"]').should('exist');
     cy.get('svg[class*="fa-dollar-sign"]').should('exist');
     cy.get('svg[class*="fa-user-group"]').should('exist');
@@ -77,8 +77,8 @@ describe('Test organization list', () => {
     });
     cy.visit('/organizations');
 
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'nxt Engineering GmbH');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
   });
 });
 
@@ -154,7 +154,7 @@ describe('Test limited permissions', () => {
     setOrganization(cy, org);
     cy.visit('/organizations');
     cy.get('#organizations-title').should('contain.text', 'Organizations');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'vshn');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
     cy.get('svg[class*="fa-pen-to-square"]').should('not.exist');
     cy.get('svg[class*="fa-dollar-sign"]').should('not.exist');
     cy.get('svg[class*="fa-user-group"]').should('exist');

--- a/cypress/e2e/teams.cy.ts
+++ b/cypress/e2e/teams.cy.ts
@@ -165,7 +165,7 @@ describe('Test team edit', () => {
 
     cy.get(':nth-child(2) > .flex-row > :nth-child(2) > [title="Edit team"]').click();
 
-    cy.get('.text-3xl').should('contain.text', 'My Super Team 1');
+    cy.get('.text-3xl').should('contain.text', 'team1');
     cy.get('#displayName').type('{selectall}Awesome Team!');
 
     cy.get(':nth-child(3) > :nth-child(3) > .p-ripple').click();

--- a/cypress/e2e/teams.cy.ts
+++ b/cypress/e2e/teams.cy.ts
@@ -25,6 +25,7 @@ describe('Test teams list', () => {
     cy.get('#teams-title').should('contain.text', 'Teams');
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
     cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 2');
+    cy.get(':nth-child(4) > .flex-row > .text-3xl').should('contain.text', 'team-no-display-name');
   });
 
   it('failed requests are retried', () => {

--- a/cypress/e2e/teams.cy.ts
+++ b/cypress/e2e/teams.cy.ts
@@ -23,8 +23,8 @@ describe('Test teams list', () => {
 
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'team2');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 2');
   });
 
   it('failed requests are retried', () => {
@@ -47,8 +47,8 @@ describe('Test teams list', () => {
     cy.visit('/teams');
 
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'team2');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 2');
   });
 
   it('list with one team and user with default organization', () => {
@@ -64,7 +64,7 @@ describe('Test teams list', () => {
 
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'tarazed');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'Tarazed');
   });
 
   it('list with one team and user with default organization and change of selected organization', () => {
@@ -80,10 +80,10 @@ describe('Test teams list', () => {
 
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'tarazed');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'Tarazed');
     cy.get('app-organization-selection:visible').click().contains('nxt').click();
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'team2');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 2');
   });
 
   it('empty list', () => {
@@ -164,7 +164,7 @@ describe('Test team edit', () => {
 
     cy.get(':nth-child(2) > .flex-row > :nth-child(2) > [title="Edit team"]').click();
 
-    cy.get('.text-3xl').should('contain.text', 'team1');
+    cy.get('.text-3xl').should('contain.text', 'My Super Team 1');
     cy.get('#displayName').type('{selectall}Awesome Team!');
 
     cy.get(':nth-child(3) > :nth-child(3) > .p-ripple').click();
@@ -194,7 +194,7 @@ describe('Test team edit', () => {
     });
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
     cy.get(':nth-child(2) > .flex-row > :nth-child(2) > [title="Edit team"]').should('not.exist');
   });
 });
@@ -258,7 +258,7 @@ describe('Test teams add', () => {
         expect(body.spec.displayName).to.eq('New Team!');
         expect(body.spec.userRefs[0].name).to.eq('test');
       });
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'new-team');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'New Team');
   });
 
   it('no create permission', () => {
@@ -317,7 +317,7 @@ describe('Test teams delete', () => {
     );
     cy.get('.p-confirm-dialog-accept').click();
     cy.wait('@delete');
-    cy.get(':nth-child(2) > .flex-row > :nth-child(1)').should('not.contain.text', 'team1');
+    cy.get(':nth-child(2) > .flex-row > :nth-child(1)').should('not.contain.text', 'My Super Team 1');
   });
 
   it('no delete permission', () => {
@@ -333,7 +333,7 @@ describe('Test teams delete', () => {
     });
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
 
     cy.get(':nth-child(2) > .flex-row > :nth-child(2) > [title="Delete team"]').should('not.exist');
   });

--- a/cypress/e2e/user.cy.ts
+++ b/cypress/e2e/user.cy.ts
@@ -111,8 +111,8 @@ describe('Test user', () => {
 
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'team1');
-    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'team2');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 1');
+    cy.get(':nth-child(3) > .flex-row > .text-3xl').should('contain.text', 'My Super Team 2');
 
     cy.visit('/user');
     cy.intercept('GET', 'appuio-api/apis/organization.appuio.io/v1/organizations', {
@@ -132,7 +132,7 @@ describe('Test user', () => {
     });
     cy.visit('/teams');
     cy.get('#teams-title').should('contain.text', 'Teams');
-    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'tarazed');
+    cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'Tarazed');
   });
 
   it('with change of default organization to None', () => {

--- a/cypress/fixtures/team.ts
+++ b/cypress/fixtures/team.ts
@@ -33,6 +33,11 @@ export const teamListNxt = createTeamList({
       displayName: 'My Super Team 2',
       userRefs: [{ name: 'cma' }],
     }),
+    createTeam({
+      name: 'team-no-display-name',
+      namespace: 'nxt',
+      userRefs: [{ name: 'ste' }],
+    }),
   ],
 });
 export const teamListVshn = createTeamList({

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -66,12 +66,6 @@
         <div class="flex flex-wrap border-top-1 surface-border">
           <ul class="w-full list-none p-0 m-0 surface-border">
             <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
-              <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
-              <div class="text-900 w-full md:w-9">
-                {{ p.billingEntity.spec.name }}
-              </div>
-            </li>
-            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
               <div class="text-500 w-full md:w-3 font-medium" i18n>ID</div>
               <div class="text-900 w-full md:w-9">
                 {{ p.billingEntity.metadata.name }}

--- a/src/app/billingentity/billing-entity.component.html
+++ b/src/app/billingentity/billing-entity.component.html
@@ -34,7 +34,7 @@
       <div class="surface-card p-4 shadow-2 border-round mb-4">
         <div class="flex flex-row justify-content-between">
           <div class="text-3xl font-medium text-900 mb-3">
-            {{ p.billingEntity.metadata.name }}
+            {{ p.billingEntity | displayName }}
           </div>
           <div>
             <a
@@ -69,6 +69,12 @@
               <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
               <div class="text-900 w-full md:w-9">
                 {{ p.billingEntity.spec.name }}
+              </div>
+            </li>
+            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+              <div class="text-500 w-full md:w-3 font-medium" i18n>ID</div>
+              <div class="text-900 w-full md:w-9">
+                {{ p.billingEntity.metadata.name }}
               </div>
             </li>
             <li

--- a/src/app/billingentity/billing-entity.component.ts
+++ b/src/app/billingentity/billing-entity.component.ts
@@ -22,6 +22,7 @@ import { RippleModule } from 'primeng/ripple';
 import { ButtonModule } from 'primeng/button';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
+import { DisplayNamePipe } from '../display-name.pipe';
 
 @Component({
   selector: 'app-billing-entity',
@@ -39,6 +40,7 @@ import { LetDirective } from '@ngrx/component';
     NgFor,
     MessagesModule,
     SharedModule,
+    DisplayNamePipe,
   ],
 })
 export class BillingEntityComponent implements OnInit {

--- a/src/app/billingentity/billingentity-detail/billing-entity-detail.component.html
+++ b/src/app/billingentity/billingentity-detail/billing-entity-detail.component.html
@@ -1,9 +1,16 @@
 <ng-container *ngrxLet="viewModel$ as vm; suspenseTpl: loading; error as err">
   <ng-container *ngIf="vm">
-    <div class="surface-card p-4 shadow-2 border-round mb-4">
+    <div class="surface-card p-4 shadow-2 border-round mb-4" *ngrxLet="isEditing$ as isEditing">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3" id="title">
-          <span *ngIf="!isNewBE(vm.billingEntity); else newBillingTitle">{{ vm.billingEntity | displayName }}</span>
+          <span *ngIf="!isNewBE(vm.billingEntity); else newBillingTitle">
+            <ng-container *ngIf="isEditing">
+              {{ vm.billingEntity.metadata.name }}
+            </ng-container>
+            <ng-container *ngIf="!isEditing">
+              {{ vm.billingEntity | displayName }}
+            </ng-container>
+          </span>
           <ng-template #newBillingTitle>
             <span i18n>New Billing</span>
           </ng-template>
@@ -26,8 +33,8 @@
           </a>
         </div>
       </div>
-      <app-billingentity-view *ngIf="!(isEditing$ | ngrxPush)" [billingEntity]="vm.billingEntity" />
-      <app-billingentity-form *ngIf="isEditing$ | ngrxPush" [billingEntity]="vm.billingEntity" />
+      <app-billingentity-view *ngIf="!isEditing" [billingEntity]="vm.billingEntity" />
+      <app-billingentity-form *ngIf="isEditing" [billingEntity]="vm.billingEntity" />
     </div>
   </ng-container>
 

--- a/src/app/billingentity/billingentity-detail/billing-entity-detail.component.html
+++ b/src/app/billingentity/billingentity-detail/billing-entity-detail.component.html
@@ -3,7 +3,7 @@
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3" id="title">
-          <span *ngIf="!isNewBE(vm.billingEntity); else newBillingTitle">{{ vm.billingEntity.metadata.name }}</span>
+          <span *ngIf="!isNewBE(vm.billingEntity); else newBillingTitle">{{ vm.billingEntity | displayName }}</span>
           <ng-template #newBillingTitle>
             <span i18n>New Billing</span>
           </ng-template>

--- a/src/app/billingentity/billingentity-detail/billing-entity-detail.component.ts
+++ b/src/app/billingentity/billingentity-detail/billing-entity-detail.component.ts
@@ -12,6 +12,7 @@ import { BackLinkDirective } from '../../shared/back-link.directive';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { NgIf } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 @Component({
   selector: 'app-billingentity-detail',
@@ -30,6 +31,7 @@ import { LetDirective, PushPipe } from '@ngrx/component';
     MessagesModule,
     SharedModule,
     PushPipe,
+    DisplayNamePipe,
   ],
 })
 export class BillingEntityDetailComponent implements OnInit {

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.html
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.html
@@ -124,9 +124,8 @@
         By registering a billing address, you agree that you will get charged for using VSHN products. You also agree to
         our
         <a href="https://legal.docs.vshn.ch/legal/gtc_en.html" target="_blank" class="text-blue-500 hover:text-primary">
-          general terms and conditions
+          general terms and conditions.
         </a>
-        .
       </small>
     </div>
     <button

--- a/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
+++ b/src/app/billingentity/billingentity-form/billing-entity-form.component.ts
@@ -154,12 +154,12 @@ export class BillingEntityFormComponent implements OnInit {
     if (this.isNewBillingEntity(be)) {
       this.billingService.add(be).subscribe({
         next: (result) => this.saveOrUpdateSuccess(result),
-        error: this.saveOrUpdateFailure,
+        error: () => this.saveOrUpdateFailure(),
       });
     } else {
       this.billingService.update(be).subscribe({
         next: (result) => this.saveOrUpdateSuccess(result),
-        error: this.saveOrUpdateFailure,
+        error: () => this.saveOrUpdateFailure(),
       });
     }
   }

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.html
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.html
@@ -3,7 +3,7 @@
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">
-          {{ payload.billingEntity.metadata.name }}
+          {{ payload.billingEntity | displayName }}
           <span i18n>Members</span>
         </div>
         <a appBackLink="../.." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -27,6 +27,7 @@ import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
 import { NotificationService } from '../../core/notification.service';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 interface Payload {
   billingEntity: BillingEntity;
@@ -57,6 +58,7 @@ interface Payload {
     MessagesModule,
     SharedModule,
     PushPipe,
+    DisplayNamePipe,
   ],
 })
 export class BillingEntityMembersComponent implements OnInit, OnDestroy {

--- a/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
+++ b/src/app/billingentity/billingentity-members/billing-entity-members.component.ts
@@ -258,13 +258,13 @@ export class BillingEntityMembersComponent implements OnInit, OnDestroy {
     forkJoin(upsert$).subscribe({
       next: () => {
         this.notificationService.showSuccessMessage(
-          $localize`Successfully saved Billing ${payload.billingEntity.metadata.name}.`
+          $localize`Successfully saved Billing ${DisplayNamePipe.transform(payload.billingEntity)}.`
         );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.route });
       },
       error: () => {
         this.notificationService.showErrorMessage(
-          $localize`Could not save Billing ${payload.billingEntity.metadata.name}.`
+          $localize`Could not save Billing ${DisplayNamePipe.transform(payload.billingEntity)}.`
         );
       },
     });

--- a/src/app/billingentity/billingentity-view/billing-entity-view.component.html
+++ b/src/app/billingentity/billingentity-view/billing-entity-view.component.html
@@ -4,6 +4,10 @@
       <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
       <div class="text-900 w-full md:w-9">{{ billingEntity.spec.name }}</div>
     </li>
+    <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+      <div class="text-500 w-full md:w-3 font-medium" i18n>ID</div>
+      <div class="text-900 w-full md:w-9">{{ billingEntity.metadata.name }}</div>
+    </li>
     <li *ngIf="billingEntity.spec.emails" class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
       <div class="text-500 w-full md:w-3 font-medium" i18n>Company Email</div>
       <div class="text-900 w-full md:w-9">

--- a/src/app/display-name.pipe.ts
+++ b/src/app/display-name.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'displayName',
+  standalone: true,
+})
+export class DisplayNamePipe implements PipeTransform {
+  transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
+    return value.spec?.displayName || value.spec?.name || value.metadata?.name || '';
+  }
+}

--- a/src/app/display-name.pipe.ts
+++ b/src/app/display-name.pipe.ts
@@ -1,15 +1,17 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+type EntityWithDisplayName = { spec?: { name?: string; displayName?: string }; metadata?: { name: string } };
+
 @Pipe({
   name: 'displayName',
   standalone: true,
 })
 export class DisplayNamePipe implements PipeTransform {
-  static transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
+  static transform(value: EntityWithDisplayName): string {
     return value.spec?.displayName || value.spec?.name || value.metadata?.name || '';
   }
 
-  transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
+  transform(value: EntityWithDisplayName): string {
     return DisplayNamePipe.transform(value);
   }
 }

--- a/src/app/display-name.pipe.ts
+++ b/src/app/display-name.pipe.ts
@@ -5,7 +5,11 @@ import { Pipe, PipeTransform } from '@angular/core';
   standalone: true,
 })
 export class DisplayNamePipe implements PipeTransform {
-  transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
+  static transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
     return value.spec?.displayName || value.spec?.name || value.metadata?.name || '';
+  }
+
+  transform(value: { spec?: { name?: string; displayName?: string }; metadata?: { name: string } }): string {
+    return DisplayNamePipe.transform(value);
   }
 }

--- a/src/app/organizations/organization-edit/organization-edit.component.html
+++ b/src/app/organizations/organization-edit/organization-edit.component.html
@@ -5,7 +5,7 @@
         <div id="title" class="text-3xl font-medium text-900 mb-3">
           <span *ngIf="isNew; else isNotNew" i18n>New Organization</span>
           <ng-template #isNotNew>
-            {{ payload.organization | displayName }}
+            {{ payload.organization.metadata.name }}
           </ng-template>
         </div>
         <a appBackLink=".." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/organizations/organization-edit/organization-edit.component.html
+++ b/src/app/organizations/organization-edit/organization-edit.component.html
@@ -5,7 +5,7 @@
         <div id="title" class="text-3xl font-medium text-900 mb-3">
           <span *ngIf="isNew; else isNotNew" i18n>New Organization</span>
           <ng-template #isNotNew>
-            {{ payload.organization.metadata.name }}
+            {{ payload.organization | displayName }}
           </ng-template>
         </div>
         <a appBackLink=".." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/organizations/organization-edit/organization-edit.component.ts
+++ b/src/app/organizations/organization-edit/organization-edit.component.ts
@@ -13,6 +13,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 interface Payload {
   organization: Organization;
@@ -33,6 +34,7 @@ interface Payload {
     OrganizationFormComponent,
     MessagesModule,
     SharedModule,
+    DisplayNamePipe,
   ],
 })
 export class OrganizationEditComponent implements OnInit {

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -19,6 +19,7 @@ import { NgIf } from '@angular/common';
 import { InputTextModule } from 'primeng/inputtext';
 import { NotificationService } from '../../core/notification.service';
 import { DataServiceError } from '@ngrx/data';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 @Component({
   selector: 'app-organization-form',
@@ -137,8 +138,8 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
       rawValue.billingEntity?.value.metadata.name ?? ''
     );
     this.organizationCollectionService.add(org).subscribe({
-      next: () => this.saveOrUpdateSuccess(),
-      error: (err) => this.saveOrUpdateFailure(err),
+      next: this.saveOrUpdateSuccess,
+      error: this.saveOrUpdateFailure,
     });
   }
 
@@ -151,12 +152,12 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
     };
     this.organizationCollectionService
       .update(org)
-      .subscribe({ next: () => this.saveOrUpdateSuccess(), error: (err) => this.saveOrUpdateFailure(err) });
+      .subscribe({ next: this.saveOrUpdateSuccess, error: this.saveOrUpdateFailure });
   }
 
-  private saveOrUpdateSuccess(): void {
+  private saveOrUpdateSuccess(org: Organization): void {
     this.notificationService.showSuccessMessage(
-      $localize`Successfully saved organization '${this.form.getRawValue().displayName}'.`
+      $localize`Successfully saved organization '${DisplayNamePipe.transform(org)}'.`
     );
     const firstTime = this.activatedRoute.snapshot.queryParamMap.get('firstTime') === 'y';
     if (firstTime) {
@@ -171,10 +172,12 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
   }
 
   private saveOrUpdateFailure(err: DataServiceError): void {
-    let message = $localize`Could not save organization '${this.form.get('organizationId')?.value}'.`;
+    const orgId = this.form.controls.organizationId.value;
+    const name = this.form.controls.displayName.value || orgId;
+    let message = $localize`Could not save organization '${name}'.`;
     if (409 === err.error?.status || err.message?.includes('already exists')) {
-      this.form.get('organizationId')?.setErrors({ alreadyExists: true });
-      message = $localize`Organization "${this.form.get('organizationId')?.value}" already exists.`;
+      this.form.controls.organizationId.setErrors({ alreadyExists: true });
+      message = $localize`Organization with ID "${orgId}" already exists.`;
     }
     this.notificationService.showErrorMessage(message);
   }

--- a/src/app/organizations/organization-form/organization-form.component.ts
+++ b/src/app/organizations/organization-form/organization-form.component.ts
@@ -138,8 +138,8 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
       rawValue.billingEntity?.value.metadata.name ?? ''
     );
     this.organizationCollectionService.add(org).subscribe({
-      next: this.saveOrUpdateSuccess,
-      error: this.saveOrUpdateFailure,
+      next: (org) => this.saveOrUpdateSuccess(org),
+      error: (err) => this.saveOrUpdateFailure(err),
     });
   }
 
@@ -150,9 +150,10 @@ export class OrganizationFormComponent implements OnInit, OnDestroy {
       displayName: rawValue.displayName ?? '',
       billingEntityRef: rawValue.billingEntity?.value.metadata.name,
     };
-    this.organizationCollectionService
-      .update(org)
-      .subscribe({ next: this.saveOrUpdateSuccess, error: this.saveOrUpdateFailure });
+    this.organizationCollectionService.update(org).subscribe({
+      next: (org) => this.saveOrUpdateSuccess(org),
+      error: (err) => this.saveOrUpdateFailure(err),
+    });
   }
 
   private saveOrUpdateSuccess(org: Organization): void {

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.html
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.html
@@ -3,7 +3,7 @@
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
         <div class="text-3xl font-medium text-900 mb-3">
-          {{ payload.members.metadata.namespace }}
+          {{ payload.organization | displayName }}
           <span i18n>Members</span>
         </div>
         <a appBackLink="../.." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -203,12 +203,14 @@ export class OrganizationMembersEditComponent implements OnInit {
     ]).subscribe({
       next: () => {
         this.notificationService.showSuccessMessage(
-          $localize`Successfully saved changes to '${payload.members.metadata.namespace}'.`
+          $localize`Successfully saved '${DisplayNamePipe.transform(payload.organization)}'.`
         );
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: () => {
-        this.notificationService.showErrorMessage($localize`Could not save changes.`);
+        this.notificationService.showErrorMessage(
+          $localize`Could not save changes for '${DisplayNamePipe.transform(payload.organization)}'.`
+        );
       },
     });
   }

--- a/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
+++ b/src/app/organizations/organization-members-edit/organization-members-edit.component.ts
@@ -20,11 +20,15 @@ import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
 import { NotificationService } from '../../core/notification.service';
+import { OrganizationCollectionService } from '../../store/organization-collection.service';
+import { Organization } from '../../types/organization';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 interface Payload {
   members: OrganizationMembers;
   roleBindings: RoleBinding[];
   canEdit: boolean;
+  organization: Organization;
 }
 
 @Component({
@@ -47,6 +51,7 @@ interface Payload {
     RippleModule,
     MessagesModule,
     SharedModule,
+    DisplayNamePipe,
   ],
 })
 export class OrganizationMembersEditComponent implements OnInit {
@@ -76,7 +81,8 @@ export class OrganizationMembersEditComponent implements OnInit {
     private membersService: OrganizationMembersCollectionService,
     private rolebindingService: RolebindingCollectionService,
     private navigationService: NavigationService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private organizationService: OrganizationCollectionService
   ) {}
 
   get userRefs(): FormArray | undefined {
@@ -92,10 +98,11 @@ export class OrganizationMembersEditComponent implements OnInit {
     this.payload$ = this.membersService.getByKeyMemoized(`${name}/members`).pipe(
       combineLatestWith(
         this.membersService.canEditMembers(name),
-        this.rolebindingService.getAllInNamespaceMemoized(name)
+        this.rolebindingService.getAllInNamespaceMemoized(name),
+        this.organizationService.getByKeyMemoized(name)
       ),
-      map(([members, canEdit, roleBindings]) => {
-        const payload = { members, canEdit, roleBindings } satisfies Payload;
+      map(([members, canEdit, roleBindings, organization]) => {
+        const payload = { members, canEdit, roleBindings, organization } satisfies Payload;
         this.initForm(payload);
         return payload;
       })

--- a/src/app/organizations/organizations.component.html
+++ b/src/app/organizations/organizations.component.html
@@ -29,7 +29,7 @@
       <div class="surface-card p-4 shadow-2 border-round mb-4">
         <div class="flex flex-row justify-content-between">
           <div class="text-3xl font-medium text-900 mb-3">
-            {{ dto.organization.metadata.name }}
+            {{ dto.organization | displayName }}
           </div>
           <div>
             <a
@@ -37,7 +37,9 @@
               [routerLink]="['/billingentities', dto.organization.spec.billingEntityRef]"
               class="text-blue-500 hover:text-primary cursor-pointer ml-3"
               i18n-title
-              title="View '{{ dto.organization.status?.billingEntityName ?? dto.organization.spec.billingEntityRef }}'">
+              title="View Billing '{{
+                dto.organization.status?.billingEntityName ?? dto.organization.spec.billingEntityRef
+              }}'">
               <fa-icon [icon]="faDollarSign" />
             </a>
             <a
@@ -61,9 +63,25 @@
         <div class="flex flex-wrap border-top-1 surface-border">
           <ul class="w-full list-none p-0 m-0 surface-border">
             <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+              <div class="text-500 w-full md:w-3 font-medium" i18n>ID</div>
+              <div class="text-900 w-full md:w-9">
+                {{ dto.organization.metadata.name }}
+              </div>
+            </li>
+            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
               <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
               <div class="text-900 w-full md:w-9">
                 {{ dto.organization.spec.displayName }}
+              </div>
+            </li>
+            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+              <div class="text-500 w-full md:w-3 font-medium" i18n>Billing Entity</div>
+              <div class="text-900 w-full md:w-9">
+                <a
+                  class="text-blue-500 hover:text-primary cursor-pointer no-underline"
+                  [routerLink]="['/billingentities', dto.organization.spec.billingEntityRef]">
+                  {{ dto.organization.status?.billingEntityName ?? dto.organization.spec.billingEntityRef }}
+                </a>
               </div>
             </li>
           </ul>

--- a/src/app/organizations/organizations.component.html
+++ b/src/app/organizations/organizations.component.html
@@ -68,7 +68,7 @@
                 {{ dto.organization.metadata.name }}
               </div>
             </li>
-            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <li class="flex align-items-center py-2 px-2 flex-wrap">
               <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
               <div class="text-900 w-full md:w-9">
                 {{ dto.organization.spec.displayName }}

--- a/src/app/organizations/organizations.component.ts
+++ b/src/app/organizations/organizations.component.ts
@@ -9,7 +9,6 @@ import {
   faUserGroup,
   faWarning,
 } from '@fortawesome/free-solid-svg-icons';
-import { DialogService } from 'primeng/dynamicdialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { OrganizationCollectionService } from '../store/organization-collection.service';
 import { Organization } from '../types/organization';
@@ -23,6 +22,7 @@ import { RippleModule } from 'primeng/ripple';
 import { ButtonModule } from 'primeng/button';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
+import { DisplayNamePipe } from '../display-name.pipe';
 
 @Component({
   selector: 'app-organizations',
@@ -40,6 +40,7 @@ import { LetDirective } from '@ngrx/component';
     NgFor,
     MessagesModule,
     SharedModule,
+    DisplayNamePipe,
   ],
 })
 export class OrganizationsComponent implements OnInit, OnDestroy {
@@ -55,7 +56,6 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
   organizations$?: Observable<ViewModel>;
 
   constructor(
-    private dialogService: DialogService,
     private router: Router,
     private activatedRoute: ActivatedRoute,
     public organizationService: OrganizationCollectionService,

--- a/src/app/teams/team-edit/team-edit.component.html
+++ b/src/app/teams/team-edit/team-edit.component.html
@@ -5,7 +5,7 @@
         <div class="text-3xl font-medium text-900 mb-3">
           <span *ngIf="new; else isNotNew" i18n>New Team</span>
           <ng-template #isNotNew>
-            {{ team | displayName }}
+            {{ team.metadata.name }}
           </ng-template>
         </div>
         <a appBackLink="../.." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/teams/team-edit/team-edit.component.html
+++ b/src/app/teams/team-edit/team-edit.component.html
@@ -5,7 +5,7 @@
         <div class="text-3xl font-medium text-900 mb-3">
           <span *ngIf="new; else isNotNew" i18n>New Team</span>
           <ng-template #isNotNew>
-            {{ team.metadata.name }}
+            {{ team | displayName }}
           </ng-template>
         </div>
         <a appBackLink="../.." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/teams/team-edit/team-edit.component.ts
+++ b/src/app/teams/team-edit/team-edit.component.ts
@@ -17,6 +17,7 @@ import { BackLinkDirective } from '../../shared/back-link.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective, PushPipe } from '@ngrx/component';
 import { NotificationService } from '../../core/notification.service';
+import { DisplayNamePipe } from '../../display-name.pipe';
 
 @Component({
   selector: 'app-team-edit',
@@ -38,6 +39,7 @@ import { NotificationService } from '../../core/notification.service';
     MessagesModule,
     SharedModule,
     PushPipe,
+    DisplayNamePipe
   ],
 })
 export class TeamEditComponent implements OnInit {

--- a/src/app/teams/team-edit/team-edit.component.ts
+++ b/src/app/teams/team-edit/team-edit.component.ts
@@ -39,7 +39,7 @@ import { DisplayNamePipe } from '../../display-name.pipe';
     MessagesModule,
     SharedModule,
     PushPipe,
-    DisplayNamePipe
+    DisplayNamePipe,
   ],
 })
 export class TeamEditComponent implements OnInit {
@@ -97,14 +97,16 @@ export class TeamEditComponent implements OnInit {
     team = this.getTeamFromForm(team);
     (this.new ? this.teamService.add(team) : this.teamService.update(team)).subscribe({
       next: () => {
-        this.notificationService.showSuccessMessage($localize`Team "${team.metadata.name}" saved.`);
+        this.notificationService.showSuccessMessage($localize`Team '${DisplayNamePipe.transform(team)}' saved.`);
         void this.router.navigate([this.navigationService.previousLocation()], { relativeTo: this.activatedRoute });
       },
       error: (error) => {
-        let message = $localize`Could not save team '${this.form.get('name')?.value}'. `;
+        const id = this.form.controls.name.value;
+        const name = this.form.controls.displayName.value || id;
+        let message = $localize`Could not save team '${name}'. `;
         if (409 === error.error.status || error.message?.includes('already exists')) {
-          this.form.get('name')?.setErrors({ alreadyExists: true });
-          message = $localize`Team '${this.form.get('name')?.value}' already exists.`;
+          this.form.controls.name.setErrors({ alreadyExists: true });
+          message = $localize`Team with name '${id}' already exists.`;
         }
         this.notificationService.showErrorMessage(message);
       },

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -61,13 +61,13 @@
                 {{ team.metadata.name }}
               </div>
             </li>
-            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+            <li class="flex align-items-center py-2 px-2 flex-wrap">
               <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
               <div class="text-900 w-full md:w-9">
                 {{ team.spec.displayName }}
               </div>
             </li>
-            <li class="flex align-items-center py-2 px-2 flex-wrap">
+            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
               <div class="text-500 w-full md:w-3 font-medium" i18n>Members</div>
               <div class="text-900 w-full md:w-9">
                 <ul *ngFor="let user of team.spec.userRefs" class="pl-3">

--- a/src/app/teams/teams.component.html
+++ b/src/app/teams/teams.component.html
@@ -31,7 +31,7 @@
       <div class="surface-card p-4 shadow-2 border-round mb-4">
         <div class="flex flex-row justify-content-between">
           <div class="text-3xl font-medium text-900 mb-3">
-            {{ team.metadata.name }}
+            {{ team | displayName }}
           </div>
           <div>
             <a
@@ -55,6 +55,12 @@
 
         <div class="flex flex-wrap border-top-1 surface-border">
           <ul class="w-full list-none p-0 m-0 surface-border">
+            <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
+              <div class="text-500 w-full md:w-3 font-medium" i18n>ID</div>
+              <div class="text-900 w-full md:w-9">
+                {{ team.metadata.name }}
+              </div>
+            </li>
             <li class="flex align-items-center py-2 px-2 flex-wrap surface-ground">
               <div class="text-500 w-full md:w-3 font-medium" i18n>Display Name</div>
               <div class="text-900 w-full md:w-9">

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -142,7 +142,7 @@ export class TeamsComponent implements OnInit, OnDestroy {
   }
 
   deleteTeam(team: Team): void {
-    const teamName = team.spec.displayName || team.metadata.name;
+    const teamName = DisplayNamePipe.transform(team);
     this.confirmationService.confirm({
       header: 'Delete team',
       message: $localize`Are you sure that you want to delete the team '${teamName}'?`,

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -19,6 +19,7 @@ import { ButtonModule } from 'primeng/button';
 import { NgIf, NgFor } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
 import { NotificationService } from '../core/notification.service';
+import { DisplayNamePipe } from '../display-name.pipe';
 
 interface Payload {
   organization?: Organization;
@@ -44,6 +45,7 @@ interface Payload {
     NgFor,
     MessagesModule,
     SharedModule,
+    DisplayNamePipe,
   ],
 })
 export class TeamsComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## Summary

Uses the entity's display name as title and in messages, if the display name is not set, falls back to the entity's name.

## Changes

 - Display name as title for lists, forms, and in messages
 - Summary cards in the overview list for Billing, Organizations, and Teams now also show the ID (aka `metadata.name`) as it's not the visual title anymore

<details>

<summary>Screenshots</summary>

<img width="1306" alt="Screenshot Billing List" src="https://github.com/appuio/cloud-portal/assets/5945974/97cd4295-6d2e-4304-9291-7b6f8f5a1c38">

<img width="1306" alt="Screenshot Teams Overview" src="https://github.com/appuio/cloud-portal/assets/5945974/8cbd72a6-55fa-472c-a55c-4069e4044105">

<img width="1306" alt="Screenshot Organizations View" src="https://github.com/appuio/cloud-portal/assets/5945974/35dd84bc-fc79-46dc-8d37-eae3830881f2">

</details>


Closes https://github.com/appuio/cloud-portal/issues/492

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`,
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
