### PR TITLE
Remove offline_access scope to fix double login

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import { TitleCasePipe } from '@angular/common';
 const authCodeFlowConfig: AuthConfig = {
   redirectUri: window.location.origin + window.location.pathname,
   responseType: 'code',
-  scope: 'openid profile email roles offline_access web-origins',
+  scope: 'openid profile email roles web-origins',
 };
 
 if (environment.production) {


### PR DESCRIPTION
## Summary

- Users currently have to log in twice: once for portal.appuio.cloud and again for the OpenShift console. The `offline_access` scope in the OIDC authorization request causes Keycloak to require explicit consent on every login, which prevents a normal SSO session from being established. Without an SSO session, navigating to the OpenShift console triggers a second login prompt.
- Removes `offline_access` from the OIDC scope. The app only uses the ID token (via the interceptor for appuio-api calls), and a regular session-bound refresh token is sufficient for `setupAutomaticSilentRefresh()` to keep tokens fresh.

## Test plan

- [ ] Log in to portal.appuio.cloud — should no longer show a Keycloak consent screen
- [ ] Navigate to the OpenShift console from the portal — should SSO through without a second login
- [ ] Verify automatic token refresh still works (leave the portal open and confirm API calls continue working after the initial token expires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)