### PR TITLE
Replace HubSpot analytics with Plausible

### DIFF
--- a/cypress/e2e/app-cat.cy.ts
+++ b/cypress/e2e/app-cat.cy.ts
@@ -5,7 +5,6 @@ describe('Test AppCat embed', () => {
   beforeEach(() => {
     // needed for initial getUser request
     cy.setPermission({ verb: 'list', resource: 'zones', group: 'rbac.appuio.io' });
-    cy.disableCookieBanner();
   });
 
   it('shows the application catalog', () => {

--- a/cypress/e2e/billingentities.cy.ts
+++ b/cypress/e2e/billingentities.cy.ts
@@ -6,7 +6,6 @@ describe('Test billing entity list', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -63,7 +62,6 @@ describe('no permissions', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -108,7 +106,6 @@ describe('Test billing entity details', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/billingentity-form.cy.ts
+++ b/cypress/e2e/billingentity-form.cy.ts
@@ -7,7 +7,6 @@ describe('Test billing entity form elements', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -180,7 +179,6 @@ describe('Test billing entity create', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -292,7 +290,6 @@ describe('Test billing entity edit', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/billingentity-members.cy.ts
+++ b/cypress/e2e/billingentity-members.cy.ts
@@ -10,7 +10,6 @@ describe('billing entity edit members with existing roles', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -295,7 +294,6 @@ describe('billing entity edit members without initial roles', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/first-time-login.cy.ts
+++ b/cypress/e2e/first-time-login.cy.ts
@@ -12,7 +12,6 @@ describe('Test First Time Login', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.removeItem('hideFirstTimeLoginDialog');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // we assume we don't have the user object yet.
@@ -120,7 +119,6 @@ describe('hide dialog', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.removeItem('hideFirstTimeLoginDialog');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -169,7 +167,6 @@ describe('skip dialog', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.removeItem('hideFirstTimeLoginDialog');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/invitations-accept.cy.ts
+++ b/cypress/e2e/invitations-accept.cy.ts
@@ -7,7 +7,6 @@ import { OrganizationPermissions } from '../../src/app/types/organization';
 describe('Test token storage and retrieval', () => {
   beforeEach(() => {
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     cy.setPermission();
@@ -63,7 +62,6 @@ describe('Test invitation accept for existing user', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
     cy.setPermission({ verb: 'list', ...OrganizationPermissions });
     cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
       body: userMigWithoutPreferences,
@@ -294,7 +292,6 @@ describe('Test invitation accept for new user', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'false');
-    cy.disableCookieBanner();
     cy.setPermission();
     cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
       statusCode: 404,

--- a/cypress/e2e/invitations-create.cy.ts
+++ b/cypress/e2e/invitations-create.cy.ts
@@ -11,7 +11,6 @@ describe('Test invitation create', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -198,7 +197,6 @@ describe('limited permissions', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -283,7 +281,6 @@ describe('degradation', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/invitations.cy.ts
+++ b/cypress/e2e/invitations.cy.ts
@@ -8,7 +8,6 @@ describe('Test invitation list', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -75,7 +74,6 @@ describe('no permissions', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -97,7 +95,6 @@ describe('invitation details', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/kubeconfig.cy.ts
+++ b/cypress/e2e/kubeconfig.cy.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 describe('Test kubeconfig', () => {
   beforeEach(() => {
     cy.setupAuth();
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/organization-form.cy.ts
+++ b/cypress/e2e/organization-form.cy.ts
@@ -20,7 +20,6 @@ describe('Test organization add', () => {
       body: createUser({ username: 'mig', defaultOrganizationRef: 'nxt' }),
     });
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('add organization with button', () => {
@@ -169,7 +168,6 @@ describe('Test organization edit', () => {
       body: createUser({ username: 'mig', defaultOrganizationRef: 'nxt' }),
     });
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('edit organization with button', () => {

--- a/cypress/e2e/organization-members.cy.ts
+++ b/cypress/e2e/organization-members.cy.ts
@@ -9,7 +9,6 @@ describe('Test organization members', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/organizations.cy.ts
+++ b/cypress/e2e/organizations.cy.ts
@@ -14,7 +14,6 @@ describe('Test organization list', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     cy.setPermission({ verb: 'list', ...OrganizationPermissions });
@@ -86,7 +85,6 @@ describe('Test limited permissions', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/e2e/productboard.cy.ts
+++ b/cypress/e2e/productboard.cy.ts
@@ -5,7 +5,6 @@ describe('Test Productboard embed', () => {
   beforeEach(() => {
     // needed for initial getUser request
     cy.setPermission({ verb: 'list', resource: 'zones', group: 'rbac.appuio.io' });
-    cy.disableCookieBanner();
   });
 
   it('shows kubeconfig', () => {

--- a/cypress/e2e/status.cy.ts
+++ b/cypress/e2e/status.cy.ts
@@ -5,7 +5,6 @@ import { ZonePermissions } from '../../src/app/types/zone';
 describe('Test zones', () => {
   beforeEach(() => {
     cy.setupAuth();
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     cy.setPermission({ verb: 'list', ...ZonePermissions });

--- a/cypress/e2e/teams.cy.ts
+++ b/cypress/e2e/teams.cy.ts
@@ -7,7 +7,6 @@ describe('Test teams list', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('list with two entries', () => {
@@ -133,7 +132,6 @@ describe('Test team edit', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('edit team with button', () => {
@@ -204,7 +202,6 @@ describe('Test teams add', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('add team with button', () => {
@@ -284,7 +281,6 @@ describe('Test teams delete', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
 
   it('delete team with button', () => {

--- a/cypress/e2e/user.cy.ts
+++ b/cypress/e2e/user.cy.ts
@@ -8,7 +8,6 @@ describe('Test user', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
     cy.setPermission();
   });
 
@@ -174,7 +173,6 @@ describe('Test failures', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
     cy.setPermission();
   });
 

--- a/cypress/e2e/zones.cy.ts
+++ b/cypress/e2e/zones.cy.ts
@@ -6,7 +6,6 @@ describe('Test zones', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request
@@ -75,7 +74,6 @@ describe('Test single zone', () => {
   beforeEach(() => {
     cy.setupAuth();
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
-    cy.disableCookieBanner();
   });
   beforeEach(() => {
     // needed for initial getUser request

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -8,7 +8,6 @@ declare namespace Cypress {
       ...permission: { verb: string; resource: string; group: string; namespace?: string; name?: string }[]
     ): typeof setPermission;
 
-    disableCookieBanner(): typeof disableCookieBanner;
   }
 }
 
@@ -79,10 +78,5 @@ function setupAuth(): void {
   window.sessionStorage.setItem('id_token_stored_at', time);
 }
 
-function disableCookieBanner(): void {
-  cy.setCookie('__hs_opt_out', 'yes');
-}
-
 Cypress.Commands.add('setupAuth', setupAuth);
 Cypress.Commands.add('setPermission', setPermission);
-Cypress.Commands.add('disableCookieBanner', disableCookieBanner);

--- a/src/index.html
+++ b/src/index.html
@@ -16,8 +16,11 @@
   </head>
   <body>
     <app-root></app-root>
-    <!-- Start of HubSpot Embed Code -->
-    <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/7105834.js"></script>
-    <!-- End of HubSpot Embed Code -->
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-Cg9JQSxgzGwoe77hhy1oa.js"></script>
+    <script>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Remove HubSpot tracking script (`js.hs-scripts.com/7105834.js`) which was causing e2e test failures — its autotrack click handler calls `.includes()` on non-string DOM properties in PrimeNG dropdown items, throwing `TypeError: e.includes is not a function`
- Replace with privacy-friendly Plausible analytics
- Remove the `disableCookieBanner` Cypress helper and all its usages across 17 e2e test files, since the HubSpot cookie banner no longer exists

## Test plan

- [x] `organization-form.cy.ts` e2e tests pass locally (5/5, previously 3/5)
- [ ] Full e2e suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)