### PR TITLE
Improve invitations-accept e2e test stability

### DIFF
--- a/cypress/e2e/invitations-accept.cy.ts
+++ b/cypress/e2e/invitations-accept.cy.ts
@@ -4,6 +4,12 @@ import { createInvitation } from '../fixtures/invitations';
 import { organizationNxt, organizationVshn, setOrganization } from '../fixtures/organization';
 import { OrganizationPermissions } from '../../src/app/types/organization';
 
+// noinspection SpellCheckingInspection -- test fixture UUIDs
+const INVITATION_URL = '/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559'; // gitleaks:allow
+const INVITATION_URL_WITH_TOKEN = `${INVITATION_URL}?token=93c05fe3-b20f-48cf-aea6-39eb2350d640`; // gitleaks:allow
+const INVITATION_API = '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559';
+const REDEEM_API = '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests';
+
 describe('Test token storage and retrieval', () => {
   beforeEach(() => {
     window.localStorage.setItem('hideFirstTimeLoginDialog', 'true');
@@ -13,48 +19,29 @@ describe('Test token storage and retrieval', () => {
   });
 
   it('should store token in local storage', () => {
-    cy.intercept('GET', '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559', {
-      statusCode: 403,
-    });
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
-    cy.getAllLocalStorage().then((result) => {
-      const expected = {
-        'http://localhost:4200': {
-          hideFirstTimeLoginDialog: 'true',
-          [invitationTokenLocalStorageKey]: '93c05fe3-b20f-48cf-aea6-39eb2350d640',
-        },
-      };
-      console.debug('expected', expected);
-      console.debug('result', result);
-      expect(result).to.deep.eq(expected);
-    });
+    cy.intercept('GET', INVITATION_API, { statusCode: 403 });
+    cy.visit(INVITATION_URL_WITH_TOKEN);
+    cy.window()
+      .its('localStorage')
+      .invoke('getItem', invitationTokenLocalStorageKey)
+      .should('eq', '93c05fe3-b20f-48cf-aea6-39eb2350d640'); // gitleaks:allow
   });
 
   it('should retrieve token from local storage after redirect', () => {
     cy.setupAuth();
-    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', {
-      statusCode: 403,
-    });
-    cy.intercept('GET', '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559', {
-      statusCode: 403,
-    });
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('GET', 'appuio-api/apis/appuio.io/v1/users/mig', { statusCode: 403 });
+    cy.intercept('GET', INVITATION_API, { statusCode: 403 });
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     });
-    window.localStorage.setItem(invitationTokenLocalStorageKey, '93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    window.localStorage.setItem(invitationTokenLocalStorageKey, '93c05fe3-b20f-48cf-aea6-39eb2350d640'); // gitleaks:allow
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559');
-    cy.get('.text-3xl').should('contain.text', 'Loading');
-    cy.getAllLocalStorage().then((result) => {
-      const expected = {
-        'http://localhost:4200': {
-          hideFirstTimeLoginDialog: 'true',
-        },
-      };
-      console.debug('expected', expected);
-      console.debug('result', result);
-      expect(result).to.deep.eq(expected);
-    });
+    cy.visit(INVITATION_URL);
+    cy.get('[data-cy="invitation-loading"]').should('contain.text', 'Loading');
+    cy.window()
+      .its('localStorage')
+      .invoke('getItem', invitationTokenLocalStorageKey)
+      .should('be.null');
   });
 });
 
@@ -69,101 +56,91 @@ describe('Test invitation accept for existing user', () => {
   });
 
   it('should display message if already redeemed', () => {
-    cy.intercept('GET', '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559', {
+    cy.intercept('GET', INVITATION_API, {
       body: createInvitation({ hasStatus: true, redeemed: 'redeemed' }),
     }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@getInvitation');
     cy.get('#redeemed-message').should('contain.text', 'Invitation is already redeemed.');
   });
 
   it('should display success message', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
 
     let interceptCount = 0;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        if (interceptCount === 0) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'pending',
-              organizations: [{ name: 'nxt', condition: 'Unknown' }],
-            })
-          );
-        } else if (interceptCount >= 1) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'True' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      if (interceptCount === 0) {
+        interceptCount++;
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'pending',
+            organizations: [{ name: 'nxt', condition: 'Unknown' }],
+          })
+        );
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'True' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
     cy.get('#title').should('contain.text', 'Invitation');
-    cy.get('.flex-row > .text-3xl', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
     cy.get('p-toast').should('contain.text', 'Invitation accepted');
   });
 
   it('should accept but display message if some targets failed', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
 
     let interceptCount = 0;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        if (interceptCount === 0) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'pending',
-              organizations: [{ name: 'nxt', condition: 'Unknown' }],
-            })
-          );
-        } else if (interceptCount >= 1) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'False' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      if (interceptCount === 0) {
+        interceptCount++;
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'pending',
+            organizations: [{ name: 'nxt', condition: 'Unknown' }],
+          })
+        );
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'False' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
     cy.wait('@getInvitation');
     cy.get('p-toast').should('contain.text', 'not all permissions could be granted');
-    cy.get('.flex-row > .text-3xl').should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]').should('contain.text', 'dev@nxt.engineering');
   });
 
   it('should display error message if redeem failed', () => {
-    cy.intercept('GET', '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559', {
+    cy.intercept('GET', INVITATION_API, {
       body: createInvitation({
         hasStatus: true,
         organizations: [{ name: 'nxt' }],
       }),
     });
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', {
+    cy.intercept('POST', REDEEM_API, {
       statusCode: 403,
       body: {
         kind: 'Status',
@@ -173,16 +150,16 @@ describe('Test invitation accept for existing user', () => {
       },
     }).as('createRequest');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createRequest');
-    cy.get('.flex-row > .text-3xl').should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]').should('contain.text', 'dev@nxt.engineering');
     cy.get('p-toast')
       .should('contain.text', 'Redeem failed')
       .and('contain.text', 'Not allowed, most likely already redeemed');
   });
 
   it('should reload entities after redeeming', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
     cy.intercept('GET', 'appuio-api/apis/organization.appuio.io/v1/organizations/nxt', {
@@ -200,40 +177,35 @@ describe('Test invitation accept for existing user', () => {
     }).as('organizationList');
 
     let invitationInterceptCount = 0;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        if (invitationInterceptCount === 0) {
-          invitationInterceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'pending',
-              organizations: [{ name: 'nxt', condition: 'Unknown' }],
-            })
-          );
-        } else if (invitationInterceptCount >= 1) {
-          invitationInterceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'True' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      if (invitationInterceptCount === 0) {
+        invitationInterceptCount++;
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'pending',
+            organizations: [{ name: 'nxt', condition: 'Unknown' }],
+          })
+        );
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'True' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
     cy.visit('/organizations');
     cy.get(':nth-child(2) > .flex-row > .text-3xl').should('contain.text', 'VSHN - the DevOps Company');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
     cy.wait('@getInvitation');
     cy.get('#title').should('contain.text', 'Invitation');
-    cy.get('.flex-row > .text-3xl').should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]').should('contain.text', 'dev@nxt.engineering');
     cy.get('p-toast').should('contain.text', 'Invitation accepted');
 
     cy.get('app-navbar-item').contains('Organizations').click();
@@ -242,7 +214,7 @@ describe('Test invitation accept for existing user', () => {
   });
 
   it('should display message even if navigated away', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
     cy.intercept('GET', 'appuio-api/apis/organization.appuio.io/v1/organizations/nxt', {
@@ -252,32 +224,28 @@ describe('Test invitation accept for existing user', () => {
     setOrganization(cy, organizationNxt);
 
     let invitationInterceptCount = -1;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        invitationInterceptCount++;
-        if (invitationInterceptCount <= 1) {
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'pending',
-              organizations: [{ name: 'nxt', condition: 'Unknown' }],
-            })
-          );
-        } else {
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'True' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      invitationInterceptCount++;
+      if (invitationInterceptCount <= 1) {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'pending',
+            organizations: [{ name: 'nxt', condition: 'Unknown' }],
+          })
+        );
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'True' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
 
     cy.get('#title').should('contain.text', 'Invitation');
@@ -299,77 +267,65 @@ describe('Test invitation accept for new user', () => {
   });
 
   it('should display success message', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
 
     let interceptCount = 0;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        if (interceptCount === 0) {
-          interceptCount++;
-          req.reply(403);
-        } else if (interceptCount >= 1) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'True' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      if (interceptCount === 0) {
+        interceptCount++;
+        req.reply(403);
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'True' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
     cy.wait('@getInvitation');
     cy.get('#title').should('contain.text', 'Invitation');
-    cy.get('.flex-row > .text-3xl', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]', { timeout: 7000 }).should('contain.text', 'dev@nxt.engineering');
     cy.get('p-toast').should('contain.text', 'Invitation accepted');
   });
 
   it('should accept but display message if some targets failed', () => {
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', (req) => {
+    cy.intercept('POST', REDEEM_API, (req) => {
       req.reply(req.body);
     }).as('createInvitationRedeemRequest');
 
     let interceptCount = 0;
-    cy.intercept(
-      'GET',
-      '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559',
-      (req) => {
-        if (interceptCount === 0) {
-          interceptCount++;
-          req.reply(403);
-        } else if (interceptCount >= 1) {
-          interceptCount++;
-          req.reply(
-            createInvitation({
-              hasStatus: true,
-              redeemed: 'redeemed',
-              organizations: [{ name: 'nxt', condition: 'False' }],
-            })
-          );
-        }
+    cy.intercept('GET', INVITATION_API, (req) => {
+      if (interceptCount === 0) {
+        interceptCount++;
+        req.reply(403);
+      } else {
+        req.reply(
+          createInvitation({
+            hasStatus: true,
+            redeemed: 'redeemed',
+            organizations: [{ name: 'nxt', condition: 'False' }],
+          })
+        );
       }
-    ).as('getInvitation');
+    }).as('getInvitation');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createInvitationRedeemRequest');
     cy.wait('@getInvitation');
     cy.get('p-toast').should('contain.text', 'not all permissions could be granted');
-    cy.get('.flex-row > .text-3xl').should('contain.text', 'dev@nxt.engineering');
+    cy.get('[data-cy="invitation-email"]').should('contain.text', 'dev@nxt.engineering');
   });
 
   it('should display error message if redeem failed', () => {
-    cy.intercept('GET', '/appuio-api/apis/user.appuio.io/v1/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559', {
-      statusCode: 403,
-    });
-    cy.intercept('POST', '/appuio-api/apis/user.appuio.io/v1/invitationredeemrequests', {
+    cy.intercept('GET', INVITATION_API, { statusCode: 403 });
+    cy.intercept('POST', REDEEM_API, {
       statusCode: 403,
       body: {
         kind: 'Status',
@@ -379,7 +335,7 @@ describe('Test invitation accept for new user', () => {
       },
     }).as('createRequest');
 
-    cy.visit('/invitations/e303b166-5d66-4151-8f5f-b84ba84a7559?token=93c05fe3-b20f-48cf-aea6-39eb2350d640');
+    cy.visit(INVITATION_URL_WITH_TOKEN);
     cy.wait('@createRequest');
     cy.get('#failure-message').should('contain.text', 'Invitation could not be loaded.');
     cy.get('p-toast')

--- a/src/app/invitations/invitation-detail/invitation-detail.component.html
+++ b/src/app/invitations/invitation-detail/invitation-detail.component.html
@@ -2,7 +2,7 @@
   <ng-container *ngIf="vm">
     <div class="surface-card p-4 shadow-2 border-round mb-4">
       <div class="flex flex-row justify-content-between">
-        <div class="text-3xl font-medium text-900 mb-3">
+        <div class="text-3xl font-medium text-900 mb-3" data-cy="invitation-email">
           {{ vm.model.spec.email }}
         </div>
         <a *ngIf="showCloseButton" appBackLink=".." class="text-blue-500 hover:text-primary text-2xl cursor-pointer">

--- a/src/app/invitations/invitation-view/invitation-view.component.html
+++ b/src/app/invitations/invitation-view/invitation-view.component.html
@@ -26,7 +26,7 @@
 <ng-template #loading>
   <div class="surface-card p-4 shadow-2 border-round mb-4 blink">
     <div class="flex flex-row justify-content-between">
-      <div class="text-3xl font-medium text-900 mb-3" i18n>Loading &#8230;</div>
+      <div class="text-3xl font-medium text-900 mb-3" data-cy="invitation-loading" i18n>Loading &#8230;</div>
     </div>
   </div>
 </ng-template>


### PR DESCRIPTION
## Summary

- Replace `cy.getAllLocalStorage()` exact equality checks with targeted `localStorage.getItem()` assertions — the old approach broke whenever any other code wrote to localStorage
- Add `data-cy` attributes to invitation templates (`invitation-email`, `invitation-loading`) and use them instead of brittle `.flex-row > .text-3xl` CSS selectors
- Extract repeated API paths into constants for readability
- Simplify counter-based intercept logic (remove redundant `else if`)

## Test plan

- [x] All 11 `invitations-accept.cy.ts` tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)